### PR TITLE
support for AirVPN entry-IP 3 with Wireguard protocol

### DIFF
--- a/internal/provider/airvpn/updater/servers.go
+++ b/internal/provider/airvpn/updater/servers.go
@@ -20,14 +20,14 @@ func (u *Updater) FetchServers(ctx context.Context, minServers int) (
 	}
 
 	// every API server model has:
-	// - Wireguard server using IPv4In1
-	// - Wiregard server using IPv6In1
+	// - Wireguard server using IPv4In1 and IPv4In3
+	// - Wiregard server using IPv6In1 and IPv4In3
 	// - OpenVPN TCP+UDP+SSH+SSL server with tls-auth using IPv4In1 and IPv6In1
 	// - OpenVPN TCP+UDP+SSH+SSL server with tls-auth using IPv4In2 and IPv6In2
 	// - OpenVPN TCP+UDP+SSH+SSL server with tls-crypt using IPv4In3 and IPv6In3
 	// - OpenVPN TCP+UDP+SSH+SSL server with tls-crypt using IPv6In4 and IPv6In4
-	const numberOfServersPerAPIServer = 1 + // Wireguard server using IPv4In1
-		1 + // Wiregard server using IPv6In1
+	const numberOfServersPerAPIServer = 2 + // Wireguard server using IPv4In1, IPv4In3
+		2 + // Wiregard server using IPv6In1, IPv4In3
 		4 + // OpenVPN TCP server with tls-auth using IPv4In3, IPv6In3, IPv4In4, IPv6In4
 		4 // OpenVPN UDP server with tls-auth using IPv4In3, IPv6In3, IPv4In4, IPv6In4
 	projectedNumberOfServers := numberOfServersPerAPIServer * len(data.Servers)
@@ -56,15 +56,25 @@ func (u *Updater) FetchServers(ctx context.Context, minServers int) (
 		baseWireguardServer.VPN = vpn.Wireguard
 		baseWireguardServer.WgPubKey = "PyLCXAQT8KkM4T+dUsOQfn+Ub3pGxfGlxkIApuig+hk="
 
-		ipv4WireguadServer := baseWireguardServer
-		ipv4WireguadServer.IPs = []netip.Addr{apiServer.IPv4In1}
-		ipv4WireguadServer.Hostname = apiServer.CountryCode + ".vpn.airdns.org"
-		servers = append(servers, ipv4WireguadServer)
+		ipv4In1WireguadServer := baseWireguardServer
+		ipv4In1WireguadServer.IPs = []netip.Addr{apiServer.IPv4In1}
+		ipv4In1WireguadServer.Hostname = apiServer.CountryCode + ".vpn.airdns.org"
+		servers = append(servers, ipv4In1WireguadServer)
 
-		ipv6WireguadServer := baseWireguardServer
-		ipv6WireguadServer.IPs = []netip.Addr{apiServer.IPv6In1}
-		ipv6WireguadServer.Hostname = apiServer.CountryCode + ".ipv6.vpn.airdns.org"
-		servers = append(servers, ipv6WireguadServer)
+		ipv6In1WireguadServer := baseWireguardServer
+		ipv6In1WireguadServer.IPs = []netip.Addr{apiServer.IPv6In1}
+		ipv6In1WireguadServer.Hostname = apiServer.CountryCode + ".ipv6.vpn.airdns.org"
+		servers = append(servers, ipv6In1WireguadServer)
+
+		ipv4In3WireguadServer := baseWireguardServer
+		ipv4In3WireguadServer.IPs = []netip.Addr{apiServer.IPv4In3}
+		ipv4In3WireguadServer.Hostname = apiServer.CountryCode + "3.vpn.airdns.org"
+		servers = append(servers, ipv4In3WireguadServer)
+
+		ipv6In3WireguadServer := baseWireguardServer
+		ipv6In3WireguadServer.IPs = []netip.Addr{apiServer.IPv6In3}
+		ipv6In3WireguadServer.Hostname = apiServer.CountryCode + "3.ipv6.vpn.airdns.org"
+		servers = append(servers, ipv6In3WireguadServer)
 
 		baseOpenVPNServer := baseServer
 		baseOpenVPNServer.VPN = vpn.OpenVPN


### PR DESCRIPTION
Add support for entry-IP 3 in AirVPN's Wireguard protocol. See [specs](https://airvpn.org/specs/), i incurred in this problem today.

AirVPN also supports Wireguard's standard port `51820` with entry-IP 3, but this is my very first time writing GO code so i don't know how to conditionally add it to the validation [here](https://github.com/qdm12/gluetun/blob/d4df87286e1e14c5471d09800ad8408285b44e58/internal/configuration/settings/wireguardselection.go#L73).

Tested this locally with the updater CLI command, seems to work.