### PR TITLE
feat(dns): restrict plain DNS output traffic

### DIFF
--- a/cmd/gluetun/main.go
+++ b/cmd/gluetun/main.go
@@ -394,7 +394,7 @@ func _main(ctx context.Context, buildInfo models.BuildInformation,
 	}
 
 	dnsLogger := logger.New(log.SetComponent("dns"))
-	dnsLooper, err := dns.NewLoop(allSettings.DNS, httpClient,
+	dnsLooper, err := dns.NewLoop(allSettings.DNS, httpClient, firewallConf,
 		dnsLogger)
 	if err != nil {
 		return fmt.Errorf("creating DNS loop: %w", err)

--- a/internal/dns/interfaces.go
+++ b/internal/dns/interfaces.go
@@ -1,0 +1,17 @@
+package dns
+
+import (
+	"context"
+	"net/netip"
+)
+
+type Logger interface {
+	Debug(s string)
+	Info(s string)
+	Warn(s string)
+	Error(s string)
+}
+
+type Firewall interface {
+	RestrictOutputAddrPort(ctx context.Context, addrPort netip.AddrPort) (err error)
+}

--- a/internal/dns/logger.go
+++ b/internal/dns/logger.go
@@ -1,8 +1,0 @@
-package dns
-
-type Logger interface {
-	Debug(s string)
-	Info(s string)
-	Warn(s string)
-	Error(s string)
-}

--- a/internal/dns/loop.go
+++ b/internal/dns/loop.go
@@ -24,6 +24,7 @@ type Loop struct {
 	localResolvers []netip.Addr
 	resolvConf     string
 	client         *http.Client
+	firewall       Firewall
 	logger         Logger
 	userTrigger    bool
 	start          <-chan struct{}
@@ -39,7 +40,7 @@ type Loop struct {
 const defaultBackoffTime = 10 * time.Second
 
 func NewLoop(settings settings.DNS,
-	client *http.Client, logger Logger,
+	client *http.Client, firewall Firewall, logger Logger,
 ) (loop *Loop, err error) {
 	start := make(chan struct{})
 	running := make(chan models.LoopStatus)
@@ -64,6 +65,7 @@ func NewLoop(settings settings.DNS,
 		filter:        filter,
 		resolvConf:    "/etc/resolv.conf",
 		client:        client,
+		firewall:      firewall,
 		logger:        logger,
 		userTrigger:   true,
 		start:         start,

--- a/internal/dns/run.go
+++ b/internal/dns/run.go
@@ -24,7 +24,7 @@ func (l *Loop) Run(ctx context.Context, done chan<- struct{}) {
 			"and go through your container network DNS outside the VPN tunnel!")
 	} else {
 		const fallback = false
-		l.useUnencryptedDNS(fallback)
+		l.useUnencryptedDNS(ctx, fallback)
 	}
 
 	select {
@@ -56,7 +56,7 @@ func (l *Loop) Run(ctx context.Context, done chan<- struct{}) {
 
 			if !errors.Is(err, errUpdateBlockLists) {
 				const fallback = true
-				l.useUnencryptedDNS(fallback)
+				l.useUnencryptedDNS(ctx, fallback)
 			}
 			l.logAndWait(ctx, err)
 			settings = l.GetSettings()
@@ -66,7 +66,7 @@ func (l *Loop) Run(ctx context.Context, done chan<- struct{}) {
 		settings = l.GetSettings()
 		if !*settings.KeepNameserver && !*settings.ServerEnabled {
 			const fallback = false
-			l.useUnencryptedDNS(fallback)
+			l.useUnencryptedDNS(ctx, fallback)
 		}
 
 		l.userTrigger = false
@@ -94,7 +94,7 @@ func (l *Loop) runWait(ctx context.Context, runError <-chan error) (exitLoop boo
 			settings := l.GetSettings()
 			if !*settings.KeepNameserver && *settings.ServerEnabled {
 				const fallback = false
-				l.useUnencryptedDNS(fallback)
+				l.useUnencryptedDNS(ctx, fallback)
 				l.stopServer()
 			}
 			l.stopped <- struct{}{}
@@ -105,7 +105,7 @@ func (l *Loop) runWait(ctx context.Context, runError <-chan error) (exitLoop boo
 		case err := <-runError: // unexpected error
 			l.statusManager.SetStatus(constants.Crashed)
 			const fallback = true
-			l.useUnencryptedDNS(fallback)
+			l.useUnencryptedDNS(ctx, fallback)
 			l.logAndWait(ctx, err)
 			return false
 		}

--- a/internal/firewall/delete_test.go
+++ b/internal/firewall/delete_test.go
@@ -69,8 +69,8 @@ func Test_deleteIPTablesRule(t *testing.T) {
 		"invalid_instruction": {
 			instruction: "invalid",
 			errWrapped:  ErrIptablesCommandMalformed,
-			errMessage: "parsing iptables command: iptables command is malformed: " +
-				"fields count 1 is not even: \"invalid\"",
+			errMessage: "parsing iptables command: parsing \"invalid\": " +
+				"iptables command is malformed: flag \"invalid\" requires a value, but got none",
 		},
 		"list_error": {
 			instruction: "-t nat --delete PREROUTING -i tun0 -p tcp --dport 43716 -j REDIRECT --to-ports 5678",

--- a/internal/firewall/firewall.go
+++ b/internal/firewall/firewall.go
@@ -29,6 +29,7 @@ type Config struct {
 	outboundSubnets   []netip.Prefix
 	allowedInputPorts map[uint16]map[string]struct{} // port to interfaces set mapping
 	portRedirections  portRedirections
+	outputAddrPort    map[uint16]netip.Addr
 	stateMutex        sync.Mutex
 }
 
@@ -52,6 +53,7 @@ func NewConfig(ctx context.Context, logger Logger,
 		runner:            runner,
 		logger:            logger,
 		allowedInputPorts: make(map[uint16]map[string]struct{}),
+		outputAddrPort:    make(map[uint16]netip.Addr),
 		ipTables:          iptables,
 		ip6Tables:         ip6tables,
 		customRulesPath:   "/iptables/post-rules.txt",

--- a/internal/firewall/iptablesmix.go
+++ b/internal/firewall/iptablesmix.go
@@ -2,6 +2,7 @@ package firewall
 
 import (
 	"context"
+	"fmt"
 )
 
 func (c *Config) runMixedIptablesInstructions(ctx context.Context, instructions []string) error {
@@ -18,4 +19,16 @@ func (c *Config) runMixedIptablesInstruction(ctx context.Context, instruction st
 		return err
 	}
 	return c.runIP6tablesInstruction(ctx, instruction)
+}
+
+func (c *Config) runIPv4AndV6IptablesInstructions(ctx context.Context,
+	ipv4Instructions, ipv6Instructions []string,
+) error {
+	if err := c.runIptablesInstructions(ctx, ipv4Instructions); err != nil {
+		return fmt.Errorf("running iptables instructions: %w", err)
+	}
+	if err := c.runIP6tablesInstructions(ctx, ipv6Instructions); err != nil {
+		return fmt.Errorf("running ip6tables instructions: %w", err)
+	}
+	return nil
 }

--- a/internal/firewall/parse_test.go
+++ b/internal/firewall/parse_test.go
@@ -23,19 +23,19 @@ func Test_parseIptablesInstruction(t *testing.T) {
 		"uneven_fields": {
 			s:          "-A",
 			errWrapped: ErrIptablesCommandMalformed,
-			errMessage: "iptables command is malformed: fields count 1 is not even: \"-A\"",
+			errMessage: "parsing \"-A\": iptables command is malformed: flag \"-A\" requires a value, but got none",
 		},
 		"unknown_key": {
 			s:          "-x something",
 			errWrapped: ErrIptablesCommandMalformed,
-			errMessage: "parsing \"-x something\": iptables command is malformed: unknown key \"-x\"",
+			errMessage: "parsing \"-x something\": iptables command is malformed: unknown flag \"-x\"",
 		},
 		"one_pair": {
-			s: "-A INPUT",
+			s: "-I INPUT",
 			instruction: iptablesInstruction{
-				table:  "filter",
-				chain:  "INPUT",
-				append: true,
+				table:     "filter",
+				chain:     "INPUT",
+				operation: opInsert,
 			},
 		},
 		"instruction_A": {
@@ -43,7 +43,7 @@ func Test_parseIptablesInstruction(t *testing.T) {
 			instruction: iptablesInstruction{
 				table:           "filter",
 				chain:           "INPUT",
-				append:          true,
+				operation:       opAppend,
 				inputInterface:  "tun0",
 				protocol:        "tcp",
 				source:          netip.MustParsePrefix("1.2.3.4/32"),
@@ -57,7 +57,7 @@ func Test_parseIptablesInstruction(t *testing.T) {
 			instruction: iptablesInstruction{
 				table:           "nat",
 				chain:           "PREROUTING",
-				append:          false,
+				operation:       opDelete,
 				inputInterface:  "tun0",
 				protocol:        "tcp",
 				destinationPort: 43716,

--- a/internal/firewall/ports.go
+++ b/internal/firewall/ports.go
@@ -3,6 +3,7 @@ package firewall
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"strconv"
 )
 
@@ -79,5 +80,135 @@ func (c *Config) RemoveAllowedPort(ctx context.Context, port uint16) (err error)
 	// All interfaces were removed successfully, so remove the port entry.
 	delete(c.allowedInputPorts, port)
 
+	return nil
+}
+
+// RestrictOutputAddrPort allows outgoing traffic to a specific IP and port for both tcp and udp,
+// while blocking other tcp or udp traffic to that port going to other IP addresses, both IPv4 and IPv6.
+// If the port was previously allowed for another IP address, that previous allowance will be removed.
+// Giving an invalid address will remove any existing restrictions for the port specified.
+func (c *Config) RestrictOutputAddrPort(ctx context.Context, addrPort netip.AddrPort) (err error) {
+	c.stateMutex.Lock()
+	defer c.stateMutex.Unlock()
+	existingIP := c.outputAddrPort[addrPort.Port()]
+
+	switch {
+	case existingIP == addrPort.Addr():
+		return nil
+	case !addrPort.Addr().IsValid():
+		// invalid address, remove any existing rules for the port
+		return c.removeOutputAddrPortRestriction(ctx, existingIP, addrPort.Port())
+	case !existingIP.IsValid():
+		// no previous existing address for the port
+		return c.insertOutputAddrPortRestriction(ctx, addrPort)
+	default:
+		// existing rule in the same IP family or different family
+		return c.replaceOutputAddrPortRestriction(ctx, existingIP, addrPort)
+	}
+}
+
+func (c *Config) removeOutputAddrPortRestriction(ctx context.Context, existingIP netip.Addr, port uint16) (err error) {
+	commonInstructions := []string{
+		fmt.Sprintf("--delete OUTPUT -p udp --dport %d -j DROP", port),
+		fmt.Sprintf("--delete OUTPUT -p tcp --dport %d -j DROP", port),
+	}
+	ipv4Instructions := commonInstructions
+	ipv6Instructions := commonInstructions
+
+	familySpecificInstructions := []string{
+		fmt.Sprintf("--delete OUTPUT -p udp --dport %d -d %s -j ACCEPT", port, existingIP),
+		fmt.Sprintf("--delete OUTPUT -p tcp --dport %d -d %s -j ACCEPT", port, existingIP),
+	}
+	if existingIP.Is4() {
+		ipv4Instructions = append(ipv4Instructions, familySpecificInstructions...)
+	} else {
+		ipv6Instructions = append(ipv6Instructions, familySpecificInstructions...)
+	}
+
+	err = c.runIPv4AndV6IptablesInstructions(ctx, ipv4Instructions, ipv6Instructions)
+	if err != nil {
+		return err
+	}
+	delete(c.outputAddrPort, port)
+	return nil
+}
+
+func (c *Config) insertOutputAddrPortRestriction(ctx context.Context, addrPort netip.AddrPort) (err error) {
+	commonInstructions := []string{
+		fmt.Sprintf("--insert OUTPUT -p udp --dport %d -j DROP", addrPort.Port()),
+		fmt.Sprintf("--insert OUTPUT -p tcp --dport %d -j DROP", addrPort.Port()),
+	}
+	ipv4Instructions := commonInstructions
+	ipv6Instructions := commonInstructions
+
+	familySpecificInstructions := []string{
+		fmt.Sprintf("--insert OUTPUT -p udp --dport %d -d %s -j ACCEPT", addrPort.Port(), addrPort.Addr()),
+		fmt.Sprintf("--insert OUTPUT -p tcp --dport %d -d %s -j ACCEPT", addrPort.Port(), addrPort.Addr()),
+	}
+	if addrPort.Addr().Is4() {
+		ipv4Instructions = append(ipv4Instructions, familySpecificInstructions...)
+	} else {
+		ipv6Instructions = append(ipv6Instructions, familySpecificInstructions...)
+	}
+	err = c.runIPv4AndV6IptablesInstructions(ctx, ipv4Instructions, ipv6Instructions)
+	if err != nil {
+		return err
+	}
+	c.outputAddrPort[addrPort.Port()] = addrPort.Addr()
+	return nil
+}
+
+func (c *Config) replaceOutputAddrPortRestriction(ctx context.Context,
+	existingIP netip.Addr, addrPort netip.AddrPort,
+) (err error) {
+	for _, protocol := range [...]string{"udp", "tcp"} {
+		switch {
+		case existingIP.Is4() && addrPort.Addr().Is4():
+			oldInstruction := fmt.Sprintf("--insert OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), existingIP)
+			newInstruction := fmt.Sprintf("--insert OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), addrPort.Addr())
+			err = c.replaceIptablesRule(ctx, oldInstruction, newInstruction)
+			if err != nil {
+				return fmt.Errorf("replacing existing IPv4 rule: %w", err)
+			}
+		case existingIP.Is6() && addrPort.Addr().Is6():
+			oldInstruction := fmt.Sprintf("--insert OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), existingIP)
+			newInstruction := fmt.Sprintf("--insert OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), addrPort.Addr())
+			err = c.replaceIP6tablesRule(ctx, oldInstruction, newInstruction)
+			if err != nil {
+				return fmt.Errorf("replacing existing IPv6 rule: %w", err)
+			}
+		case existingIP.Is4() && addrPort.Addr().Is6():
+			instruction := fmt.Sprintf("--delete OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), existingIP)
+			err = c.runIptablesInstruction(ctx, instruction)
+			if err != nil {
+				return fmt.Errorf("removing existing IPv4 rule: %w", err)
+			}
+			instruction = fmt.Sprintf("--insert OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), addrPort.Addr())
+			err = c.runIP6tablesInstruction(ctx, instruction)
+			if err != nil {
+				return fmt.Errorf("inserting new IPv6 rule: %w", err)
+			}
+		case existingIP.Is6() && addrPort.Addr().Is4():
+			instruction := fmt.Sprintf("--delete OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), existingIP)
+			err = c.runIP6tablesInstruction(ctx, instruction)
+			if err != nil {
+				return fmt.Errorf("removing existing IPv6 rule: %w", err)
+			}
+			instruction = fmt.Sprintf("--insert OUTPUT -p %s --dport %d -d %s -j ACCEPT",
+				protocol, addrPort.Port(), addrPort.Addr())
+			err = c.runIptablesInstruction(ctx, instruction)
+			if err != nil {
+				return fmt.Errorf("inserting new IPv4 rule: %w", err)
+			}
+		}
+	}
+	c.outputAddrPort[addrPort.Port()] = addrPort.Addr()
 	return nil
 }

--- a/internal/firewall/replace.go
+++ b/internal/firewall/replace.go
@@ -1,0 +1,51 @@
+package firewall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var errRuleNotFound = errors.New("rule not found")
+
+func (c *Config) replaceIptablesRule(ctx context.Context, oldInstruction, newInstruction string) error {
+	targetRule, err := parseIptablesInstruction(oldInstruction)
+	if err != nil {
+		return fmt.Errorf("parsing iptables command to replace: %w", err)
+	}
+
+	lineNumber, err := findLineNumber(ctx, c.ipTables, targetRule, c.runner, c.logger)
+	if err != nil {
+		return fmt.Errorf("finding to-be-replaced chain rule line number: %w", err)
+	} else if lineNumber == 0 {
+		return fmt.Errorf("%w: matching to-be-replaced instruction %q", errRuleNotFound, oldInstruction)
+	}
+	parsed, err := parseIptablesInstruction(newInstruction)
+	if err != nil {
+		return fmt.Errorf("parsing replacement iptables command: %w", err)
+	}
+	parsed.operation = opReplace
+	parsed.lineNumber = lineNumber
+	return c.runIptablesInstruction(ctx, parsed.String())
+}
+
+func (c *Config) replaceIP6tablesRule(ctx context.Context, oldInstruction, newInstruction string) error {
+	targetRule, err := parseIptablesInstruction(oldInstruction)
+	if err != nil {
+		return fmt.Errorf("parsing iptables command to replace: %w", err)
+	}
+
+	lineNumber, err := findLineNumber(ctx, c.ip6Tables, targetRule, c.runner, c.logger)
+	if err != nil {
+		return fmt.Errorf("finding to-be-replaced chain rule line number: %w", err)
+	} else if lineNumber == 0 {
+		return fmt.Errorf("%w: matching to-be-replaced instruction %q", errRuleNotFound, oldInstruction)
+	}
+	parsed, err := parseIptablesInstruction(newInstruction)
+	if err != nil {
+		return fmt.Errorf("parsing replacement iptables command: %w", err)
+	}
+	parsed.operation = opReplace
+	parsed.lineNumber = lineNumber
+	return c.runIP6tablesInstruction(ctx, parsed.String())
+}


### PR DESCRIPTION
# Description

It turns out some VPN infrastructure spoofs plain DNS responses, at least if trying to reach a non working DNS server address such as 1.2.3.4. I'm not sure if they spoof all DNS responses, but that sounds like a security/privacy issue to me. I think it would be wise to firewall lock output PLAIN dns traffic to:

- [x] fallback plain dns address when the dns server fails
- [x] 127.0.0.1 to use the built in gluetun dns server
- [ ] local ip addresses found in /etc/resolv.conf, such that the built-in dns server local middleware can reach out to those and resolve container names etc.
- [ ] if using the plain upstream type for dns, allow those ip addresses through

One should also:

- [ ] log a warning when using a plain dns address, that dns traffic might be spoofed by the VPN infrastructure. Maybe add some code to verify if that's the case!

# Issue

Found whilst fiddling with #3109 where I had to run

```
iptables -I OUTPUT -p udp --dport 53 -j DROP
iptables -I OUTPUT -p tcp --dport 53 -j DROP
iptables -I OUTPUT -p udp -d 127.0.0.1 --dport 53 -j ACCEPT
iptables -I OUTPUT -p tcp -d 127.0.0.1 --dport 53 -j ACCEPT
```

to block plain dns from escaping

# Assertions

* [x] I am aware that we do not accept manual changes to the servers.json file <!-- If this is your goal, please consult https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-using-the-command-line -->
* [x] I am aware that any changes to settings should be reflected in the [wiki](https://github.com/qdm12/gluetun-wiki/)
