### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ services:
 
 ## Fun graphs
 
-[![Star History Chart](https://api.star-history.com/svg?repos=passteque/gluetun&type=date&legend=top-left)](https://www.star-history.com/#passteque/gluetun&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=passteque/gluetun&type=date&legend=top-left)](https://star-history.dera.page/#passteque/gluetun&type=date&legend=top-left)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub's stargazer API restrictions. This changes the chart to use star-history.dera.page, an alternative that relies on a different data source requiring no API token, restoring the chart for all visitors.