### PR TITLE
feat: add Wireguard support for Private Internet Access provider

### DIFF
--- a/internal/configuration/settings/openvpn.go
+++ b/internal/configuration/settings/openvpn.go
@@ -379,8 +379,8 @@ func (o OpenVPN) WithDefaults(provider string) OpenVPN {
 
 func (o *OpenVPN) read(r *reader.Reader) (err error) {
 	o.Version = r.String("OPENVPN_VERSION")
-	o.User = r.Get("OPENVPN_USER", reader.RetroKeys("USER"), reader.ForceLowercase(false))
-	o.Password = r.Get("OPENVPN_PASSWORD", reader.RetroKeys("PASSWORD"), reader.ForceLowercase(false))
+	o.User = r.Get("OPENVPN_USER", reader.RetroKeys("USER", "VPN_USER", "WIREGUARD_USER"), reader.ForceLowercase(false))
+	o.Password = r.Get("OPENVPN_PASSWORD", reader.RetroKeys("PASSWORD", "VPN_PASSWORD", "WIREGUARD_PASSWORD"), reader.ForceLowercase(false))
 	o.ConfFile = r.Get("OPENVPN_CUSTOM_CONFIG", reader.ForceLowercase(false))
 	o.Ciphers = r.CSV("OPENVPN_CIPHERS", reader.RetroKeys("OPENVPN_CIPHER"))
 	o.Auth = r.Get("OPENVPN_AUTH")

--- a/internal/configuration/settings/portforward.go
+++ b/internal/configuration/settings/portforward.go
@@ -236,7 +236,7 @@ func (p *PortForwarding) read(r *reader.Reader) (err error) {
 		return err
 	}
 
-	usernameKeys := []string{"VPN_PORT_FORWARDING_USERNAME", "OPENVPN_USER", "USER"}
+	usernameKeys := []string{"VPN_PORT_FORWARDING_USERNAME", "OPENVPN_USER", "USER", "VPN_USER", "WIREGUARD_USER"}
 	for _, key := range usernameKeys {
 		p.Username = r.String(key, reader.ForceLowercase(false))
 		if p.Username != "" {
@@ -244,7 +244,7 @@ func (p *PortForwarding) read(r *reader.Reader) (err error) {
 		}
 	}
 
-	passwordKeys := []string{"VPN_PORT_FORWARDING_PASSWORD", "OPENVPN_PASSWORD", "PASSWORD"}
+	passwordKeys := []string{"VPN_PORT_FORWARDING_PASSWORD", "OPENVPN_PASSWORD", "PASSWORD", "VPN_PASSWORD", "WIREGUARD_PASSWORD"}
 	for _, key := range passwordKeys {
 		p.Password = r.String(key, reader.ForceLowercase(false))
 		if p.Password != "" {

--- a/internal/configuration/settings/provider.go
+++ b/internal/configuration/settings/provider.go
@@ -49,6 +49,7 @@ func (p *Provider) validate(vpnType string, filterChoicesGetter FilterChoicesGet
 			providers.Ivpn,
 			providers.Mullvad,
 			providers.Nordvpn,
+			providers.PrivateInternetAccess,
 			providers.Protonvpn,
 			providers.Surfshark,
 			providers.Windscribe,

--- a/internal/configuration/settings/vpn.go
+++ b/internal/configuration/settings/vpn.go
@@ -1,8 +1,10 @@
 package settings
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/qdm12/gluetun/internal/constants/providers"
 	"github.com/qdm12/gluetun/internal/constants/vpn"
 	"github.com/qdm12/gosettings"
 	"github.com/qdm12/gosettings/reader"
@@ -61,6 +63,14 @@ func (v *VPN) Validate(filterChoicesGetter FilterChoicesGetter, ipv6Supported bo
 		err := v.Wireguard.validate(v.Provider.Name, ipv6Supported, amneziawg)
 		if err != nil {
 			return fmt.Errorf("Wireguard settings: %w", err)
+		}
+		if v.Provider.Name == providers.PrivateInternetAccess {
+			switch {
+			case *v.OpenVPN.User == "":
+				return errors.New("user is empty")
+			case *v.OpenVPN.Password == "":
+				return errors.New("password is empty")
+			}
 		}
 	}
 

--- a/internal/configuration/settings/vpn_test.go
+++ b/internal/configuration/settings/vpn_test.go
@@ -1,0 +1,132 @@
+package settings
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/constants/providers"
+	"github.com/qdm12/gluetun/internal/constants/vpn"
+	"github.com/qdm12/gluetun/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockFilterChoicesGetter struct {
+	choices models.FilterChoices
+}
+
+func (m mockFilterChoicesGetter) GetFilterChoices(string) models.FilterChoices {
+	return m.choices
+}
+
+func Test_VPN_Validate_PIA_Wireguard(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		vpnSettings VPN
+		err         error
+	}{
+		"valid PIA wireguard": {
+			vpnSettings: VPN{
+				Type: vpn.Wireguard,
+				Provider: Provider{
+					Name: providers.PrivateInternetAccess,
+					ServerSelection: ServerSelection{
+						VPN: vpn.Wireguard,
+					},
+					PortForwarding: PortForwarding{
+						Enabled: ptrTo(false),
+					},
+				},
+				OpenVPN: OpenVPN{
+					User:     ptrTo("piauser"),
+					Password: ptrTo("piapass"),
+				},
+				Wireguard: Wireguard{
+					PrivateKey:                  ptrTo(""),
+					PreSharedKey:                ptrTo(""),
+					AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+					PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+					Interface:                   "wg0",
+					Implementation:              "auto",
+				},
+			},
+		},
+		"PIA wireguard missing user": {
+			vpnSettings: VPN{
+				Type: vpn.Wireguard,
+				Provider: Provider{
+					Name: providers.PrivateInternetAccess,
+					ServerSelection: ServerSelection{
+						VPN: vpn.Wireguard,
+					},
+					PortForwarding: PortForwarding{
+						Enabled: ptrTo(false),
+					},
+				},
+				OpenVPN: OpenVPN{
+					User:     ptrTo(""),
+					Password: ptrTo("piapass"),
+				},
+				Wireguard: Wireguard{
+					PrivateKey:                  ptrTo(""),
+					PreSharedKey:                ptrTo(""),
+					AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+					PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+					Interface:                   "wg0",
+					Implementation:              "auto",
+				},
+			},
+			err: errors.New("user is empty"),
+		},
+		"PIA wireguard missing password": {
+			vpnSettings: VPN{
+				Type: vpn.Wireguard,
+				Provider: Provider{
+					Name: providers.PrivateInternetAccess,
+					ServerSelection: ServerSelection{
+						VPN: vpn.Wireguard,
+					},
+					PortForwarding: PortForwarding{
+						Enabled: ptrTo(false),
+					},
+				},
+				OpenVPN: OpenVPN{
+					User:     ptrTo("piauser"),
+					Password: ptrTo(""),
+				},
+				Wireguard: Wireguard{
+					PrivateKey:                  ptrTo(""),
+					PreSharedKey:                ptrTo(""),
+					AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+					PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+					Interface:                   "wg0",
+					Implementation:              "auto",
+				},
+			},
+			err: errors.New("password is empty"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			vpnSettings := testCase.vpnSettings
+			vpnSettings.setDefaults()
+
+			filterChoicesGetter := mockFilterChoicesGetter{}
+			warner := (Warner)(nil)
+			const ipv6Supported = false
+
+			err := vpnSettings.Validate(filterChoicesGetter, ipv6Supported, warner)
+
+			if testCase.err != nil {
+				assert.Equal(t, testCase.err.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/configuration/settings/wireguard.go
+++ b/internal/configuration/settings/wireguard.go
@@ -62,16 +62,19 @@ var regexpInterfaceName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 func (w Wireguard) validate(vpnProvider string, ipv6Supported, amneziawg bool) (err error) {
 	// Validate PrivateKey
 	if *w.PrivateKey == "" {
-		return errors.New("private key is not set")
-	}
-	_, err = wgtypes.ParseKey(*w.PrivateKey)
-	if err != nil {
-		err = fmt.Errorf("private key is not valid: %w", err)
-		if vpnProvider == providers.Nordvpn &&
-			err.Error() == "wgtypes: incorrect key size: 48" {
-			err = fmt.Errorf("%w - you might be using your access token instead of the Wireguard private key", err)
+		if vpnProvider != providers.PrivateInternetAccess {
+			return errors.New("private key is not set")
 		}
-		return err
+	} else if vpnProvider != providers.PrivateInternetAccess {
+		_, err = wgtypes.ParseKey(*w.PrivateKey)
+		if err != nil {
+			err = fmt.Errorf("private key is not valid: %w", err)
+			if vpnProvider == providers.Nordvpn &&
+				err.Error() == "wgtypes: incorrect key size: 48" {
+				err = fmt.Errorf("%w - you might be using your access token instead of the Wireguard private key", err)
+			}
+			return err
+		}
 	}
 
 	if vpnProvider == providers.Airvpn {
@@ -90,7 +93,9 @@ func (w Wireguard) validate(vpnProvider string, ipv6Supported, amneziawg bool) (
 
 	// Validate Addresses
 	if len(w.Addresses) == 0 {
-		return errors.New("interface address is not set")
+		if vpnProvider != providers.PrivateInternetAccess {
+			return errors.New("interface address is not set")
+		}
 	}
 	for i, ipNet := range w.Addresses {
 		if !ipNet.IsValid() {

--- a/internal/configuration/settings/wireguard_test.go
+++ b/internal/configuration/settings/wireguard_test.go
@@ -1,0 +1,89 @@
+package settings
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/constants/providers"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Wireguard_validate(t *testing.T) {
+	t.Parallel()
+
+	validKey := "yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk="
+
+	testCases := map[string]struct {
+		wireguard     Wireguard
+		vpnProvider   string
+		ipv6Supported bool
+		amneziawg     bool
+		err           error
+	}{
+		"valid PIA wireguard with empty private key and addresses": {
+			wireguard: Wireguard{
+				PrivateKey:                  ptrTo(""),
+				PreSharedKey:                ptrTo(""),
+				AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+				PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+				Interface:                   "wg0",
+				Implementation:              "auto",
+			},
+			vpnProvider: providers.PrivateInternetAccess,
+		},
+		"valid standard wireguard": {
+			wireguard: Wireguard{
+				PrivateKey:                  ptrTo(validKey),
+				PreSharedKey:                ptrTo(""),
+				Addresses:                   []netip.Prefix{netip.PrefixFrom(netip.AddrFrom4([4]byte{10, 0, 0, 2}), 32)},
+				AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+				PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+				Interface:                   "wg0",
+				Implementation:              "auto",
+			},
+			vpnProvider: providers.Mullvad,
+		},
+		"standard wireguard missing private key": {
+			wireguard: Wireguard{
+				PrivateKey:                  ptrTo(""),
+				PreSharedKey:                ptrTo(""),
+				Addresses:                   []netip.Prefix{netip.PrefixFrom(netip.AddrFrom4([4]byte{10, 0, 0, 2}), 32)},
+				AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+				PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+				Interface:                   "wg0",
+				Implementation:              "auto",
+			},
+			vpnProvider: providers.Mullvad,
+			err:         errors.New("private key is not set"),
+		},
+		"standard wireguard missing addresses": {
+			wireguard: Wireguard{
+				PrivateKey:                  ptrTo(validKey),
+				PreSharedKey:                ptrTo(""),
+				AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+				PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+				Interface:                   "wg0",
+				Implementation:              "auto",
+			},
+			vpnProvider: providers.Mullvad,
+			err:         errors.New("interface address is not set"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.wireguard.validate(testCase.vpnProvider,
+				testCase.ipv6Supported, testCase.amneziawg)
+
+			if testCase.err != nil {
+				assert.Equal(t, testCase.err.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/models/server.go
+++ b/internal/models/server.go
@@ -48,7 +48,7 @@ func (s *Server) HasMinimumInformation() (err error) {
 		return errors.New("no network protocol should be set")
 	case s.VPN == vpn.OpenVPN && !s.TCP && !s.UDP:
 		return errors.New("both TCP and UDP fields are false for OpenVPN")
-	case s.VPN == vpn.Wireguard && s.WgPubKey == "":
+	case s.VPN == vpn.Wireguard && s.WgPubKey == "" && s.ServerName == "":
 		return errors.New("wireguard public key field is empty")
 	default:
 		return nil

--- a/internal/models/server_test.go
+++ b/internal/models/server_test.go
@@ -123,3 +123,84 @@ func Test_Server_Equal(t *testing.T) {
 		})
 	}
 }
+
+func Test_Server_HasMinimumInformation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		server Server
+		err    error
+	}{
+		"valid OpenVPN server": {
+			server: Server{
+				VPN: "openvpn",
+				UDP: true,
+				IPs: []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+		},
+		"valid Wireguard server with static pubkey": {
+			server: Server{
+				VPN:      "wireguard",
+				WgPubKey: "pubkey123",
+				IPs:      []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+		},
+		"valid Wireguard server with dynamic credentials": {
+			server: Server{
+				VPN:        "wireguard",
+				ServerName: "bahamas413",
+				IPs:        []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+		},
+		"empty vpn field": {
+			server: Server{
+				IPs: []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+			err: assert.AnError,
+		},
+		"empty ips field": {
+			server: Server{
+				VPN: "openvpn",
+				UDP: true,
+			},
+			err: assert.AnError,
+		},
+		"wireguard with network protocol": {
+			server: Server{
+				VPN:      "wireguard",
+				WgPubKey: "pubkey123",
+				UDP:      true,
+				IPs:      []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+			err: assert.AnError,
+		},
+		"openvpn with no protocol": {
+			server: Server{
+				VPN: "openvpn",
+				IPs: []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+			err: assert.AnError,
+		},
+		"wireguard with empty pubkey and empty server name": {
+			server: Server{
+				VPN: "wireguard",
+				IPs: []netip.Addr{netip.AddrFrom4([4]byte{1, 2, 3, 4})},
+			},
+			err: assert.AnError,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.server.HasMinimumInformation()
+
+			if testCase.err != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/provider/common/wireguard.go
+++ b/internal/provider/common/wireguard.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/models"
+	"github.com/qdm12/gluetun/internal/wireguard"
+)
+
+type Firewall interface {
+	AcceptOutput(ctx context.Context, protocol, intf string, ip netip.Addr, port uint16, remove bool) error
+}
+
+type WireguardConfiger interface {
+	WireguardConfig(ctx context.Context, connection *models.Connection,
+		settings settings.VPN, wireguardSettings wireguard.Settings,
+		fw Firewall) (wireguard.Settings, error)
+}

--- a/internal/provider/privateinternetaccess/connection.go
+++ b/internal/provider/privateinternetaccess/connection.go
@@ -11,14 +11,16 @@ func (p *Provider) GetConnection(selection settings.ServerSelection, ipv6Support
 	connection models.Connection, err error,
 ) {
 	// Set port defaults depending on encryption preset.
-	var defaults utils.ConnectionDefaults
-	switch *selection.OpenVPN.PIAEncPreset {
-	case presets.Normal:
-		defaults.OpenVPNTCPPort = 502
-		defaults.OpenVPNUDPPort = 1198
-	case presets.Strong:
-		defaults.OpenVPNTCPPort = 8443
-		defaults.OpenVPNUDPPort = 8080
+	defaults := utils.NewConnectionDefaults(0, 0, 1337)
+	if selection.OpenVPN.PIAEncPreset != nil {
+		switch *selection.OpenVPN.PIAEncPreset {
+		case presets.Normal:
+			defaults.OpenVPNTCPPort = 502
+			defaults.OpenVPNUDPPort = 1198
+		case presets.Strong:
+			defaults.OpenVPNTCPPort = 8443
+			defaults.OpenVPNUDPPort = 8080
+		}
 	}
 
 	return utils.GetConnection(p.Name(),

--- a/internal/provider/privateinternetaccess/connection_test.go
+++ b/internal/provider/privateinternetaccess/connection_test.go
@@ -1,0 +1,130 @@
+package privateinternetaccess
+
+import (
+	"errors"
+	"net/http"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/constants"
+	"github.com/qdm12/gluetun/internal/constants/providers"
+	"github.com/qdm12/gluetun/internal/constants/vpn"
+	"github.com/qdm12/gluetun/internal/models"
+	"github.com/qdm12/gluetun/internal/provider/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_Provider_GetConnection(t *testing.T) {
+	t.Parallel()
+
+	const provider = providers.PrivateInternetAccess
+
+	testCases := map[string]struct {
+		filteredServers []models.Server
+		storageErr      error
+		selection       settings.ServerSelection
+		ipv6Supported   bool
+		connection      models.Connection
+		errMessage      string
+	}{
+		"error": {
+			storageErr: errors.New("test error"),
+			selection: settings.ServerSelection{}.WithDefaults(provider),
+			errMessage: "filtering servers: test error",
+		},
+		"default OpenVPN TCP port": {
+			filteredServers: []models.Server{
+				{
+					ServerName: "bahamas413",
+					Hostname:   "bahamas.privacy.network",
+					IPs:        []netip.Addr{netip.AddrFrom4([4]byte{1, 1, 1, 1})},
+				},
+			},
+			selection: settings.ServerSelection{
+				OpenVPN: settings.OpenVPNSelection{
+					Protocol: constants.TCP,
+				},
+			}.WithDefaults(provider),
+			connection: models.Connection{
+				Type:       vpn.OpenVPN,
+				IP:         netip.AddrFrom4([4]byte{1, 1, 1, 1}),
+				Port:       8443,
+				Protocol:   constants.TCP,
+				ServerName: "bahamas413",
+				Hostname:   "bahamas.privacy.network",
+			},
+		},
+		"default OpenVPN UDP port": {
+			filteredServers: []models.Server{
+				{
+					ServerName: "bahamas413",
+					Hostname:   "bahamas.privacy.network",
+					IPs:        []netip.Addr{netip.AddrFrom4([4]byte{1, 1, 1, 1})},
+				},
+			},
+			selection: settings.ServerSelection{
+				OpenVPN: settings.OpenVPNSelection{
+					Protocol: constants.UDP,
+				},
+			}.WithDefaults(provider),
+			connection: models.Connection{
+				Type:       vpn.OpenVPN,
+				IP:         netip.AddrFrom4([4]byte{1, 1, 1, 1}),
+				Port:       8080,
+				Protocol:   constants.UDP,
+				ServerName: "bahamas413",
+				Hostname:   "bahamas.privacy.network",
+			},
+		},
+		"default Wireguard port": {
+			filteredServers: []models.Server{
+				{
+					ServerName: "bahamas413",
+					Hostname:   "bahamas.privacy.network",
+					IPs:        []netip.Addr{netip.AddrFrom4([4]byte{1, 1, 1, 1})},
+				},
+			},
+			selection: settings.ServerSelection{
+				VPN: vpn.Wireguard,
+			}.WithDefaults(provider),
+			connection: models.Connection{
+				Type:       vpn.Wireguard,
+				IP:         netip.AddrFrom4([4]byte{1, 1, 1, 1}),
+				Port:       1337,
+				Protocol:   constants.UDP,
+				ServerName: "bahamas413",
+				Hostname:   "bahamas.privacy.network",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			storage := common.NewMockStorage(ctrl)
+			storage.EXPECT().FilterServers(provider, testCase.selection).
+				Return(testCase.filteredServers, testCase.storageErr)
+
+			timeNow := time.Now
+			client := (*http.Client)(nil)
+			provider := New(storage, timeNow, client)
+
+			connection, err := provider.GetConnection(testCase.selection, testCase.ipv6Supported)
+
+			if testCase.errMessage != "" {
+				require.Error(t, err)
+				assert.Equal(t, testCase.errMessage, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.connection, connection)
+		})
+	}
+}

--- a/internal/provider/privateinternetaccess/provider.go
+++ b/internal/provider/privateinternetaccess/provider.go
@@ -1,6 +1,7 @@
 package privateinternetaccess
 
 import (
+	"context"
 	"net/http"
 	"net/netip"
 	"time"
@@ -12,13 +13,18 @@ import (
 )
 
 type Provider struct {
-	storage    common.Storage
-	connPicker *utils.ConnectionPicker
-	timeNow    func() time.Time
+	storage         common.Storage
+	connPicker      *utils.ConnectionPicker
+	timeNow         func() time.Time
 	common.Fetcher
 	// Port forwarding
 	portForwardPath string
 	apiIP           netip.Addr
+	client          *http.Client
+	addWireguardKey func(ctx context.Context, serverName string, serverIP netip.Addr,
+		token, publicKey string) (result addKeyResult, err error)
+	fetchAuthToken  func(ctx context.Context, serverName string, serverIP netip.Addr,
+		username, password string) (token string, err error)
 }
 
 func New(storage common.Storage, timeNow func() time.Time,
@@ -31,6 +37,9 @@ func New(storage common.Storage, timeNow func() time.Time,
 		connPicker:      utils.NewConnectionPicker(),
 		portForwardPath: jsonPortForwardPath,
 		Fetcher:         updater.New(client),
+		client:          client,
+		addWireguardKey: addWireguardKey,
+		fetchAuthToken:  fetchAuthV3Token,
 	}
 }
 

--- a/internal/provider/privateinternetaccess/updater/api.go
+++ b/internal/provider/privateinternetaccess/updater/api.go
@@ -22,6 +22,7 @@ type regionData struct {
 	Servers     struct {
 		UDP []serverData `json:"ovpnudp"`
 		TCP []serverData `json:"ovpntcp"`
+		WG  []serverData `json:"wg"`
 	} `json:"servers"`
 }
 

--- a/internal/provider/privateinternetaccess/updater/hosttoserver.go
+++ b/internal/provider/privateinternetaccess/updater/hosttoserver.go
@@ -3,19 +3,19 @@ package updater
 import (
 	"net/netip"
 
-	"github.com/qdm12/gluetun/internal/constants/vpn"
 	"github.com/qdm12/gluetun/internal/models"
 )
 
 type nameToServer map[string]models.Server
 
-func (nts nameToServer) add(name, hostname, region string,
+func (nts nameToServer) add(name, hostname, region, vpnType string,
 	tcp, udp, portForward bool, ip netip.Addr,
 ) (change bool) {
-	server, ok := nts[name]
+	key := vpnType + "-" + name
+	server, ok := nts[key]
 	if !ok {
 		change = true
-		server.VPN = vpn.OpenVPN
+		server.VPN = vpnType
 		server.ServerName = name
 		server.Hostname = hostname
 		server.Region = region
@@ -44,7 +44,7 @@ func (nts nameToServer) add(name, hostname, region string,
 		server.IPs = append(server.IPs, ip)
 	}
 
-	nts[name] = server
+	nts[key] = server
 
 	return change
 }

--- a/internal/provider/privateinternetaccess/updater/servers.go
+++ b/internal/provider/privateinternetaccess/updater/servers.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/qdm12/gluetun/internal/constants/vpn"
 	"github.com/qdm12/gluetun/internal/models"
 	"github.com/qdm12/gluetun/internal/provider/common"
 )
@@ -82,14 +83,21 @@ func addData(regions []regionData, nts nameToServer) (change bool) {
 		}
 		for _, server := range region.Servers.UDP {
 			const tcp, udp = false, true
-			if nts.add(server.CN, region.DNS, region.Name, tcp, udp, region.PortForward, server.IP) {
+			if nts.add(server.CN, region.DNS, region.Name, vpn.OpenVPN, tcp, udp, region.PortForward, server.IP) {
 				change = true
 			}
 		}
 
 		for _, server := range region.Servers.TCP {
 			const tcp, udp = true, false
-			if nts.add(server.CN, region.DNS, region.Name, tcp, udp, region.PortForward, server.IP) {
+			if nts.add(server.CN, region.DNS, region.Name, vpn.OpenVPN, tcp, udp, region.PortForward, server.IP) {
+				change = true
+			}
+		}
+
+		for _, server := range region.Servers.WG {
+			const tcp, udp = false, false
+			if nts.add(server.CN, region.DNS, region.Name, vpn.Wireguard, tcp, udp, region.PortForward, server.IP) {
 				change = true
 			}
 		}

--- a/internal/provider/privateinternetaccess/updater/servers_test.go
+++ b/internal/provider/privateinternetaccess/updater/servers_test.go
@@ -1,0 +1,116 @@
+package updater
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/qdm12/gluetun/internal/constants/vpn"
+	"github.com/qdm12/gluetun/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_addData(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		regions  []regionData
+		initial  nameToServer
+		expected nameToServer
+		change   bool
+	}{
+		"empty regions": {
+			regions:  nil,
+			initial:  make(nameToServer),
+			expected: make(nameToServer),
+			change:   false,
+		},
+		"offline region": {
+			regions: []regionData{
+				{
+					Name:    "Bahamas",
+					Offline: true,
+					Servers: struct {
+						UDP []serverData `json:"ovpnudp"`
+						TCP []serverData `json:"ovpntcp"`
+						WG  []serverData `json:"wg"`
+					}{
+						WG: []serverData{
+							{CN: "bahamas413", IP: netip.AddrFrom4([4]byte{95, 181, 238, 98})},
+						},
+					},
+				},
+			},
+			initial:  make(nameToServer),
+			expected: make(nameToServer),
+			change:   false,
+		},
+		"openvpn and wireguard servers": {
+			regions: []regionData{
+				{
+					Name:        "Bahamas",
+					DNS:         "bahamas.privacy.network",
+					PortForward: true,
+					Offline:     false,
+					Servers: struct {
+						UDP []serverData `json:"ovpnudp"`
+						TCP []serverData `json:"ovpntcp"`
+						WG  []serverData `json:"wg"`
+					}{
+						UDP: []serverData{
+							{CN: "bahamas413", IP: netip.AddrFrom4([4]byte{95, 181, 238, 89})},
+						},
+						TCP: []serverData{
+							{CN: "bahamas413", IP: netip.AddrFrom4([4]byte{95, 181, 238, 106})},
+						},
+						WG: []serverData{
+							{CN: "bahamas413", IP: netip.AddrFrom4([4]byte{95, 181, 238, 98})},
+						},
+					},
+				},
+			},
+			initial: make(nameToServer),
+			expected: nameToServer{
+				"openvpn-bahamas413": models.Server{
+					VPN:         vpn.OpenVPN,
+					ServerName:  "bahamas413",
+					Hostname:    "bahamas.privacy.network",
+					Region:      "Bahamas",
+					PortForward: true,
+					UDP:         true,
+					TCP:         true,
+					IPs: []netip.Addr{
+						netip.AddrFrom4([4]byte{95, 181, 238, 89}),
+						netip.AddrFrom4([4]byte{95, 181, 238, 106}),
+					},
+				},
+				"wireguard-bahamas413": models.Server{
+					VPN:         vpn.Wireguard,
+					ServerName:  "bahamas413",
+					Hostname:    "bahamas.privacy.network",
+					Region:      "Bahamas",
+					PortForward: true,
+					IPs: []netip.Addr{
+						netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+					},
+				},
+			},
+			change: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nts := make(nameToServer)
+			for k, v := range testCase.initial {
+				nts[k] = v
+			}
+
+			change := addData(testCase.regions, nts)
+
+			assert.Equal(t, testCase.change, change)
+			assert.Equal(t, testCase.expected, nts)
+		})
+	}
+}

--- a/internal/provider/privateinternetaccess/wireguard.go
+++ b/internal/provider/privateinternetaccess/wireguard.go
@@ -1,0 +1,373 @@
+package privateinternetaccess
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/models"
+	"github.com/qdm12/gluetun/internal/provider/common"
+	"github.com/qdm12/gluetun/internal/wireguard"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+var _ common.WireguardConfiger = (*Provider)(nil)
+
+type addKeyResult struct {
+	Status     string   `json:"status"`
+	ServerKey  string   `json:"server_key"`
+	ServerPort uint16   `json:"server_port"`
+	ServerIP   string   `json:"server_ip"`
+	ServerVIP  string   `json:"server_vip"`
+	PeerIP     string   `json:"peer_ip"`
+	PeerPubkey string   `json:"peer_pubkey"`
+	DNSServers []string `json:"dns_servers"`
+	Message    string   `json:"message"`
+}
+
+func (p *Provider) WireguardConfig(ctx context.Context, connection *models.Connection,
+	vpnSettings settings.VPN, wireguardSettings wireguard.Settings,
+	fw common.Firewall,
+) (wgSettings wireguard.Settings, err error) {
+	if connection.ServerName == "" {
+		return wireguardSettings, errors.New("server name is empty")
+	}
+
+	if !connection.IP.IsValid() {
+		return wireguardSettings, errors.New("connection IP is not valid")
+	}
+
+	username := *vpnSettings.OpenVPN.User
+	if username == "" {
+		username = vpnSettings.Provider.PortForwarding.Username
+	}
+	if username == "" {
+		return wireguardSettings, errors.New("user is empty")
+	}
+
+	password := *vpnSettings.OpenVPN.Password
+	if password == "" {
+		password = vpnSettings.Provider.PortForwarding.Password
+	}
+	if password == "" {
+		return wireguardSettings, errors.New("password is empty")
+	}
+
+	privateKey, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		return wireguardSettings, fmt.Errorf("generating private key: %w", err)
+	}
+	publicKey := privateKey.PublicKey()
+
+	token, err := p.getToken(ctx, fw, connection.ServerName, connection.IP, username, password)
+	if err != nil {
+		return wireguardSettings, fmt.Errorf("fetching auth token: %w", err)
+	}
+
+	if fw != nil {
+		const remove = false
+		err = fw.AcceptOutput(ctx, "tcp", "*", connection.IP, 1337, remove)
+		if err != nil {
+			return wireguardSettings, fmt.Errorf("allowing output to wireguard port 1337: %w", err)
+		}
+		defer func() {
+			const remove = true
+			_ = fw.AcceptOutput(context.Background(), "tcp", "*", connection.IP, 1337, remove)
+		}()
+	}
+
+	result, err := p.addWireguardKey(ctx, connection.ServerName, connection.IP, token, publicKey.String())
+	if err != nil {
+		return wireguardSettings, fmt.Errorf("adding wireguard key: %w", err)
+	}
+
+	_, err = wgtypes.ParseKey(result.ServerKey)
+	if err != nil {
+		return wireguardSettings, fmt.Errorf("parsing server public key: %w", err)
+	}
+
+	peerIPString := result.PeerIP
+	if !strings.ContainsRune(peerIPString, '/') {
+		peerIPString += "/32"
+	}
+	peerPrefix, err := netip.ParsePrefix(peerIPString)
+	if err != nil {
+		return wireguardSettings, fmt.Errorf("parsing peer IP: %w", err)
+	}
+
+	wireguardSettings.PrivateKey = privateKey.String()
+	wireguardSettings.PublicKey = result.ServerKey
+	wireguardSettings.Addresses = []netip.Prefix{peerPrefix}
+
+	if wireguardSettings.PersistentKeepaliveInterval == 0 {
+		const defaultPersistentKeepalive = 25 * time.Second
+		wireguardSettings.PersistentKeepaliveInterval = defaultPersistentKeepalive
+	}
+
+	if result.ServerPort > 0 {
+		connection.Port = result.ServerPort
+	}
+	wireguardSettings.Endpoint = netip.AddrPortFrom(connection.IP, connection.Port)
+	connection.PubKey = result.ServerKey
+
+	return wireguardSettings, nil
+}
+
+func (p *Provider) getToken(ctx context.Context, fw common.Firewall,
+	serverName string, serverIP netip.Addr, username, password string,
+) (token string, err error) {
+	if p.fetchAuthToken != nil {
+		if fw != nil {
+			const remove = false
+			_ = fw.AcceptOutput(ctx, "tcp", "*", serverIP, 443, remove)
+			defer func() {
+				const remove = true
+				_ = fw.AcceptOutput(context.Background(), "tcp", "*", serverIP, 443, remove)
+			}()
+		}
+		token, err = p.fetchAuthToken(ctx, serverName, serverIP, username, password)
+		if err == nil {
+			return token, nil
+		}
+	}
+
+	if p.client != nil {
+		v2Token, v2Err := fetchTokenThroughFirewall(ctx, fw, p.client, username, password)
+		if v2Err == nil {
+			return v2Token, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("authv3 token: %w, client v2 token: %w", err, v2Err)
+		}
+		return "", fmt.Errorf("client v2 token: %w", v2Err)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return "", errors.New("cannot fetch token: no client available")
+}
+
+func fetchTokenThroughFirewall(ctx context.Context, fw common.Firewall,
+	client *http.Client, username, password string,
+) (token string, err error) {
+	const host = "www.privateinternetaccess.com"
+	resolvedIPs, err := resolveDomainThroughFirewall(ctx, fw, host)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s: %w", host, err)
+	}
+
+	if fw != nil {
+		for _, ip := range resolvedIPs {
+			const remove = false
+			_ = fw.AcceptOutput(ctx, "tcp", "*", ip, 443, remove)
+		}
+		defer func() {
+			for _, ip := range resolvedIPs {
+				const remove = true
+				_ = fw.AcceptOutput(context.Background(), "tcp", "*", ip, 443, remove)
+			}
+		}()
+	}
+
+	return fetchToken(ctx, client, username, password)
+}
+
+func resolveDomainThroughFirewall(ctx context.Context, fw common.Firewall,
+	domain string,
+) (ips []netip.Addr, err error) {
+	dnsIPs := []netip.Addr{
+		netip.AddrFrom4([4]byte{1, 1, 1, 1}),
+		netip.AddrFrom4([4]byte{1, 0, 0, 1}),
+		netip.AddrFrom4([4]byte{8, 8, 8, 8}),
+		netip.AddrFrom4([4]byte{8, 8, 4, 4}),
+		netip.AddrFrom4([4]byte{9, 9, 9, 9}),
+	}
+
+	if fw != nil {
+		for _, dnsIP := range dnsIPs {
+			const remove = false
+			_ = fw.AcceptOutput(ctx, "udp", "*", dnsIP, 53, remove)
+			_ = fw.AcceptOutput(ctx, "tcp", "*", dnsIP, 53, remove)
+		}
+		defer func() {
+			for _, dnsIP := range dnsIPs {
+				const remove = true
+				_ = fw.AcceptOutput(context.Background(), "udp", "*", dnsIP, 53, remove)
+				_ = fw.AcceptOutput(context.Background(), "tcp", "*", dnsIP, 53, remove)
+			}
+		}()
+	}
+
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{Timeout: 3 * time.Second}
+			conn, dialErr := d.DialContext(ctx, "udp", "1.1.1.1:53")
+			if dialErr == nil {
+				return conn, nil
+			}
+			conn, dialErr = d.DialContext(ctx, "udp", "8.8.8.8:53")
+			if dialErr == nil {
+				return conn, nil
+			}
+			return d.DialContext(ctx, network, address)
+		},
+	}
+
+	netIPs, err := resolver.LookupIP(ctx, "ip4", domain)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %s: %w", domain, err)
+	}
+
+	netipAddrs := make([]netip.Addr, 0, len(netIPs))
+	for _, ip := range netIPs {
+		addr, ok := netip.AddrFromSlice(ip.To4())
+		if ok {
+			netipAddrs = append(netipAddrs, addr)
+		}
+	}
+
+	if len(netipAddrs) == 0 {
+		return nil, fmt.Errorf("no IPv4 address found for %s", domain)
+	}
+
+	return netipAddrs, nil
+}
+
+func fetchAuthV3Token(ctx context.Context, serverName string, serverIP netip.Addr,
+	username, password string,
+) (token string, err error) {
+	client, err := newHTTPClient(serverName)
+	if err != nil {
+		return "", fmt.Errorf("creating HTTP client: %w", err)
+	}
+
+	return fetchAuthV3TokenWithClient(ctx, client, serverIP, username, password)
+}
+
+func fetchAuthV3TokenWithClient(ctx context.Context, client *http.Client, serverIP netip.Addr,
+	username, password string,
+) (token string, err error) {
+	const timeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	apiURL := url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(serverIP.String(), "443"),
+		Path:   "/authv3/generateToken",
+	}
+
+	errSubstitutions := map[string]string{
+		url.QueryEscape(username): "<username>",
+		url.QueryEscape(password): "<password>",
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return "", replaceInErr(err, errSubstitutions)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.SetBasicAuth(username, password)
+
+	response, err := client.Do(request)
+	if err != nil {
+		return "", replaceInErr(err, errSubstitutions)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return "", makeNOKStatusError(response, errSubstitutions)
+	}
+
+	decoder := json.NewDecoder(response.Body)
+	var result struct {
+		Token   string `json:"token"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	}
+	if err := decoder.Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Token == "" {
+		if result.Message != "" {
+			return "", fmt.Errorf("error from server: %s", result.Message)
+		}
+		return "", errors.New("token received is empty")
+	}
+
+	return result.Token, nil
+}
+
+func addWireguardKey(ctx context.Context, serverName string, serverIP netip.Addr,
+	token, publicKey string,
+) (result addKeyResult, err error) {
+	client, err := newHTTPClient(serverName)
+	if err != nil {
+		return result, fmt.Errorf("creating HTTP client: %w", err)
+	}
+
+	return addWireguardKeyWithClient(ctx, client, serverIP, token, publicKey)
+}
+
+func addWireguardKeyWithClient(ctx context.Context, client *http.Client, serverIP netip.Addr,
+	token, publicKey string,
+) (result addKeyResult, err error) {
+	const timeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	queryParams := make(url.Values)
+	queryParams.Add("pt", token)
+	queryParams.Add("pubkey", publicKey)
+
+	apiURL := url.URL{
+		Scheme:   "https",
+		Host:     net.JoinHostPort(serverIP.String(), "1337"),
+		Path:     "/addKey",
+		RawQuery: queryParams.Encode(),
+	}
+
+	errSubstitutions := map[string]string{
+		url.QueryEscape(token):     "<token>",
+		url.QueryEscape(publicKey): "<public_key>",
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return result, replaceInErr(err, errSubstitutions)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return result, replaceInErr(err, errSubstitutions)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return result, makeNOKStatusError(response, errSubstitutions)
+	}
+
+	decoder := json.NewDecoder(response.Body)
+	if err := decoder.Decode(&result); err != nil {
+		return result, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Status != "OK" {
+		return result, fmt.Errorf("server returned non-OK status %q: %s", result.Status, result.Message)
+	}
+
+	return result, nil
+}

--- a/internal/provider/privateinternetaccess/wireguard_test.go
+++ b/internal/provider/privateinternetaccess/wireguard_test.go
@@ -1,0 +1,560 @@
+package privateinternetaccess
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/qdm12/gluetun/internal/configuration/settings"
+	"github.com/qdm12/gluetun/internal/models"
+	"github.com/qdm12/gluetun/internal/wireguard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (s roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return s(r)
+}
+
+type mockFirewall struct {
+	acceptCalls []struct {
+		protocol string
+		intf     string
+		ip       netip.Addr
+		port     uint16
+		remove   bool
+	}
+	acceptErr error
+}
+
+func (m *mockFirewall) AcceptOutput(_ context.Context, protocol, intf string, ip netip.Addr, port uint16, remove bool) error {
+	if m == nil {
+		return nil
+	}
+	m.acceptCalls = append(m.acceptCalls, struct {
+		protocol string
+		intf     string
+		ip       netip.Addr
+		port     uint16
+		remove   bool
+	}{protocol: protocol, intf: intf, ip: ip, port: port, remove: remove})
+	return m.acceptErr
+}
+
+func Test_Provider_WireguardConfig(t *testing.T) {
+	t.Parallel()
+
+	testServerKey, err := wgtypes.GeneratePrivateKey()
+	require.NoError(t, err)
+	validServerPubKey := testServerKey.PublicKey().String()
+
+	testCases := map[string]struct {
+		connection        models.Connection
+		vpnSettings       settings.VPN
+		wireguardSettings wireguard.Settings
+		httpClient        *http.Client
+		firewall          *mockFirewall
+		addWireguardKey   func(ctx context.Context, serverName string, serverIP netip.Addr,
+			token, publicKey string) (result addKeyResult, err error)
+		expectedWgSettings wireguard.Settings
+		expectedConnection models.Connection
+		expectedErr        error
+	}{
+		"success": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo("user123"),
+					Password: ptrTo("pass456"),
+				},
+			},
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					assert.Equal(t, "https://www.privateinternetaccess.com/api/client/v2/token", r.URL.String())
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"token":"test-token"}`)),
+					}, nil
+				}),
+			},
+			firewall: &mockFirewall{},
+			addWireguardKey: func(_ context.Context, serverName string, serverIP netip.Addr,
+				token, publicKey string,
+			) (result addKeyResult, err error) {
+				assert.Equal(t, "bahamas413", serverName)
+				assert.Equal(t, netip.AddrFrom4([4]byte{95, 181, 238, 98}), serverIP)
+				assert.Equal(t, "test-token", token)
+				assert.NotEmpty(t, publicKey)
+				return addKeyResult{
+					Status:     "OK",
+					ServerKey:  validServerPubKey,
+					ServerPort: 1337,
+					ServerIP:   "95.181.238.98",
+					PeerIP:     "10.0.0.2",
+					PeerPubkey: publicKey,
+					DNSServers: []string{"10.0.0.242"},
+				}, nil
+			},
+			expectedWgSettings: wireguard.Settings{
+				PublicKey: validServerPubKey,
+				Addresses: []netip.Prefix{
+					netip.PrefixFrom(netip.AddrFrom4([4]byte{10, 0, 0, 2}), 32),
+				},
+				Endpoint: netip.AddrPortFrom(
+					netip.AddrFrom4([4]byte{95, 181, 238, 98}), 1337),
+				PersistentKeepaliveInterval: 25 * time.Second,
+			},
+			expectedConnection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+				Port:       1337,
+				PubKey:     validServerPubKey,
+			},
+		},
+		"empty server name": {
+			connection: models.Connection{
+				IP: netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			expectedErr: errors.New("server name is empty"),
+		},
+		"invalid connection IP": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+			},
+			expectedErr: errors.New("connection IP is not valid"),
+		},
+		"empty username": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo(""),
+					Password: ptrTo("pass456"),
+				},
+			},
+			expectedErr: errors.New("user is empty"),
+		},
+		"empty password": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo("user123"),
+					Password: ptrTo(""),
+				},
+			},
+			expectedErr: errors.New("password is empty"),
+		},
+		"token fetch failure": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo("user123"),
+					Password: ptrTo("pass456"),
+				},
+			},
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return nil, errors.New("network error")
+				}),
+			},
+			expectedErr: errors.New("fetching auth token:"),
+		},
+		"add wireguard key failure": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo("user123"),
+					Password: ptrTo("pass456"),
+				},
+			},
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"token":"test-token"}`)),
+					}, nil
+				}),
+			},
+			addWireguardKey: func(_ context.Context, _ string, _ netip.Addr,
+				_, _ string,
+			) (result addKeyResult, err error) {
+				return result, errors.New("addKey failed")
+			},
+			expectedErr: errors.New("adding wireguard key: addKey failed"),
+		},
+		"invalid server key returned": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo("user123"),
+					Password: ptrTo("pass456"),
+				},
+			},
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"token":"test-token"}`)),
+					}, nil
+				}),
+			},
+			addWireguardKey: func(_ context.Context, _ string, _ netip.Addr,
+				_, _ string,
+			) (result addKeyResult, err error) {
+				return addKeyResult{
+					Status:     "OK",
+					ServerKey:  "invalid-key",
+					ServerPort: 1337,
+					PeerIP:     "10.0.0.2",
+				}, nil
+			},
+			expectedErr: errors.New("parsing server public key:"),
+		},
+		"invalid peer ip returned": {
+			connection: models.Connection{
+				ServerName: "bahamas413",
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+			},
+			vpnSettings: settings.VPN{
+				OpenVPN: settings.OpenVPN{
+					User:     ptrTo("user123"),
+					Password: ptrTo("pass456"),
+				},
+			},
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"token":"test-token"}`)),
+					}, nil
+				}),
+			},
+			addWireguardKey: func(_ context.Context, _ string, _ netip.Addr,
+				_, _ string,
+			) (result addKeyResult, err error) {
+				return addKeyResult{
+					Status:     "OK",
+					ServerKey:  validServerPubKey,
+					ServerPort: 1337,
+					PeerIP:     "not-an-ip",
+				}, nil
+			},
+			expectedErr: errors.New("parsing peer IP:"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{
+				client:          testCase.httpClient,
+				addWireguardKey: testCase.addWireguardKey,
+			}
+
+			connection := testCase.connection
+			wgSettings, err := p.WireguardConfig(t.Context(), &connection,
+				testCase.vpnSettings, testCase.wireguardSettings, testCase.firewall)
+
+			if testCase.expectedErr != nil {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, testCase.expectedErr.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, wgSettings.PrivateKey)
+			assert.Equal(t, testCase.expectedWgSettings.PublicKey, wgSettings.PublicKey)
+			assert.Equal(t, testCase.expectedWgSettings.Addresses, wgSettings.Addresses)
+			assert.Equal(t, testCase.expectedWgSettings.Endpoint, wgSettings.Endpoint)
+			assert.Equal(t, testCase.expectedWgSettings.PersistentKeepaliveInterval, wgSettings.PersistentKeepaliveInterval)
+			assert.Equal(t, testCase.expectedConnection, connection)
+		})
+	}
+}
+
+func Test_addWireguardKeyWithClient(t *testing.T) {
+	t.Parallel()
+
+	testServerIP := netip.AddrFrom4([4]byte{95, 181, 238, 98})
+
+	testCases := map[string]struct {
+		client         *http.Client
+		expectedResult addKeyResult
+		expectedErr    error
+	}{
+		"success": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					assert.Equal(t, "https://95.181.238.98:1337/addKey?pt=test-token&pubkey=test-pubkey", r.URL.String())
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(bytes.NewBufferString(`{
+							"status": "OK",
+							"server_key": "srvkey123",
+							"server_port": 1337,
+							"server_ip": "95.181.238.98",
+							"server_vip": "10.0.0.1",
+							"peer_ip": "10.0.0.2",
+							"peer_pubkey": "test-pubkey",
+							"dns_servers": ["10.0.0.242"]
+						}`)),
+					}, nil
+				}),
+			},
+			expectedResult: addKeyResult{
+				Status:     "OK",
+				ServerKey:  "srvkey123",
+				ServerPort: 1337,
+				ServerIP:   "95.181.238.98",
+				ServerVIP:  "10.0.0.1",
+				PeerIP:     "10.0.0.2",
+				PeerPubkey: "test-pubkey",
+				DNSServers: []string{"10.0.0.242"},
+			},
+		},
+		"http status non-200": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Status:     "401 Unauthorized",
+						Request: &http.Request{
+							URL: &url.URL{
+								Scheme: "https",
+								Host:   "test.com",
+							},
+						},
+						Body: io.NopCloser(bytes.NewBufferString(`{"status":"ERROR","message":"invalid token"}`)),
+					}, nil
+				}),
+			},
+			expectedErr: errors.New("HTTP status code not OK: https://test.com: 401 401 Unauthorized: response received: status \"ERROR\" and message \"invalid token\""),
+		},
+		"server non-ok status": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"status":"ERROR","message":"bad key"}`)),
+					}, nil
+				}),
+			},
+			expectedErr: errors.New("server returned non-OK status \"ERROR\": bad key"),
+		},
+		"invalid json body": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{invalid`)),
+					}, nil
+				}),
+			},
+			expectedErr: errors.New("decoding response: invalid character 'i' looking for beginning of object key string"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := addWireguardKeyWithClient(t.Context(), testCase.client,
+				testServerIP, "test-token", "test-pubkey")
+
+			if testCase.expectedErr != nil {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, testCase.expectedErr.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedResult, result)
+		})
+	}
+}
+
+func Test_fetchAuthV3TokenWithClient(t *testing.T) {
+	t.Parallel()
+
+	testServerIP := netip.AddrFrom4([4]byte{95, 181, 238, 98})
+
+	testCases := map[string]struct {
+		client        *http.Client
+		expectedToken string
+		expectedErr   error
+	}{
+		"success": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					assert.Equal(t, "https://95.181.238.98:443/authv3/generateToken", r.URL.String())
+					user, pass, ok := r.BasicAuth()
+					assert.True(t, ok)
+					assert.Equal(t, "testuser", user)
+					assert.Equal(t, "testpass", pass)
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"token":"authv3-token"}`)),
+					}, nil
+				}),
+			},
+			expectedToken: "authv3-token",
+		},
+		"empty token with error message": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{"token":"","message":"invalid credentials"}`)),
+					}, nil
+				}),
+			},
+			expectedErr: errors.New("error from server: invalid credentials"),
+		},
+		"non-200 status": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Status:     "401 Unauthorized",
+						Request: &http.Request{
+							URL: &url.URL{
+								Scheme: "https",
+								Host:   "test.com",
+							},
+						},
+						Body: io.NopCloser(bytes.NewBufferString(`{"status":"ERROR","message":"unauthorized"}`)),
+					}, nil
+				}),
+			},
+			expectedErr: errors.New("HTTP status code not OK: https://test.com: 401 401 Unauthorized: response received: status \"ERROR\" and message \"unauthorized\""),
+		},
+		"invalid json body": {
+			client: &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(`{invalid`)),
+					}, nil
+				}),
+			},
+			expectedErr: errors.New("decoding response: invalid character 'i' looking for beginning of object key string"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			token, err := fetchAuthV3TokenWithClient(t.Context(), testCase.client,
+				testServerIP, "testuser", "testpass")
+
+			if testCase.expectedErr != nil {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, testCase.expectedErr.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedToken, token)
+		})
+	}
+}
+
+func Test_Provider_getToken(t *testing.T) {
+	t.Parallel()
+
+	testServerIP := netip.AddrFrom4([4]byte{95, 181, 238, 98})
+
+	testCases := map[string]struct {
+		provider      Provider
+		expectedToken string
+		expectedErr   error
+	}{
+		"authv3 success": {
+			provider: Provider{
+				fetchAuthToken: func(_ context.Context, _ string, _ netip.Addr, _, _ string) (string, error) {
+					return "authv3-token", nil
+				},
+			},
+			expectedToken: "authv3-token",
+		},
+		"authv3 fallback to v2 success": {
+			provider: Provider{
+				fetchAuthToken: func(_ context.Context, _ string, _ netip.Addr, _, _ string) (string, error) {
+					return "", errors.New("authv3 failed")
+				},
+				client: &http.Client{
+					Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewBufferString(`{"token":"v2-token"}`)),
+						}, nil
+					}),
+				},
+			},
+			expectedToken: "v2-token",
+		},
+		"both fail": {
+			provider: Provider{
+				fetchAuthToken: func(_ context.Context, _ string, _ netip.Addr, _, _ string) (string, error) {
+					return "", errors.New("authv3 timeout")
+				},
+				client: &http.Client{
+					Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+						return nil, errors.New("v2 network error")
+					}),
+				},
+			},
+			expectedErr: errors.New("authv3 token: authv3 timeout, client v2 token: Post \"https://www.privateinternetaccess.com/api/client/v2/token\": v2 network error"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			token, err := testCase.provider.getToken(t.Context(), (*mockFirewall)(nil), "bahamas413",
+				testServerIP, "user", "pass")
+
+			if testCase.expectedErr != nil {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, testCase.expectedErr.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedToken, token)
+		})
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/internal/vpn/interfaces.go
+++ b/internal/vpn/interfaces.go
@@ -12,6 +12,7 @@ import (
 	"github.com/qdm12/gluetun/internal/pmtud/tcp"
 	portforward "github.com/qdm12/gluetun/internal/portforward"
 	"github.com/qdm12/gluetun/internal/provider"
+	"github.com/qdm12/gluetun/internal/provider/common"
 	"github.com/qdm12/gluetun/internal/provider/utils"
 )
 
@@ -19,6 +20,7 @@ type Firewall interface {
 	SetVPNConnection(ctx context.Context, connection models.Connection, interfaceName string) error
 	SetAllowedPort(ctx context.Context, port uint16, interfaceName string) error
 	RemoveAllowedPort(ctx context.Context, port uint16) error
+	AcceptOutput(ctx context.Context, protocol, intf string, ip netip.Addr, port uint16, remove bool) error
 	tcp.Firewall
 }
 
@@ -46,6 +48,8 @@ type Provider interface {
 	OpenVPNConfig(connection models.Connection, settings settings.OpenVPN, ipv6Supported bool) (lines []string)
 	Name() string
 }
+
+type WireguardConfiger = common.WireguardConfiger
 
 type PortForwarder interface {
 	Name() string

--- a/internal/vpn/wireguard.go
+++ b/internal/vpn/wireguard.go
@@ -28,6 +28,13 @@ func setupWireguard(ctx context.Context, netlinker NetLinker,
 
 	wireguardSettings := buildWireguardSettings(connection, settings.Wireguard, ipv6SupportLevel.IsSupported())
 
+	if wgConfiger, ok := providerConf.(WireguardConfiger); ok {
+		wireguardSettings, err = wgConfiger.WireguardConfig(ctx, &connection, settings, wireguardSettings, fw)
+		if err != nil {
+			return nil, models.Connection{}, fmt.Errorf("configuring wireguard: %w", err)
+		}
+	}
+
 	logger.Debug("Wireguard server public key: " + wireguardSettings.PublicKey)
 	logger.Debug("Wireguard client private key: " + gosettings.ObfuscateKey(wireguardSettings.PrivateKey))
 	logger.Debug("Wireguard pre-shared key: " + gosettings.ObfuscateKey(wireguardSettings.PreSharedKey))

--- a/internal/vpn/wireguard_test.go
+++ b/internal/vpn/wireguard_test.go
@@ -1,12 +1,17 @@
 package vpn
 
 import (
+	"context"
+	"errors"
 	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/qdm12/gluetun/internal/configuration/settings"
 	"github.com/qdm12/gluetun/internal/models"
+	"github.com/qdm12/gluetun/internal/netlink"
+	"github.com/qdm12/gluetun/internal/provider"
+	"github.com/qdm12/gluetun/internal/provider/common"
 	"github.com/qdm12/gluetun/internal/wireguard"
 	"github.com/stretchr/testify/assert"
 )
@@ -100,6 +105,214 @@ func Test_buildWireguardSettings(t *testing.T) {
 				testCase.userSettings, testCase.ipv6Supported)
 
 			assert.Equal(t, testCase.settings, settings)
+		})
+	}
+}
+
+type mockProvider struct {
+	connection models.Connection
+	getConnErr error
+}
+
+func (m mockProvider) GetConnection(settings.ServerSelection, bool) (models.Connection, error) {
+	return m.connection, m.getConnErr
+}
+
+func (m mockProvider) OpenVPNConfig(models.Connection, settings.OpenVPN, bool) []string {
+	return nil
+}
+
+func (m mockProvider) Name() string {
+	return "mock"
+}
+
+func (m mockProvider) FetchServers(context.Context, int) ([]models.Server, error) {
+	return nil, nil
+}
+
+type mockWireguardProvider struct {
+	mockProvider
+	wireguardConfig func(ctx context.Context, connection *models.Connection,
+		settings settings.VPN, wireguardSettings wireguard.Settings,
+		fw common.Firewall) (wireguard.Settings, error)
+}
+
+func (m mockWireguardProvider) WireguardConfig(ctx context.Context, connection *models.Connection,
+	settings settings.VPN, wireguardSettings wireguard.Settings,
+	fw common.Firewall,
+) (wireguard.Settings, error) {
+	return m.wireguardConfig(ctx, connection, settings, wireguardSettings, fw)
+}
+
+type mockFirewall struct {
+	setConnErr error
+}
+
+func (m mockFirewall) SetVPNConnection(context.Context, models.Connection, string) error {
+	return m.setConnErr
+}
+
+func (m mockFirewall) SetAllowedPort(context.Context, uint16, string) error { return nil }
+func (m mockFirewall) RemoveAllowedPort(context.Context, uint16) error      { return nil }
+func (m mockFirewall) AcceptOutput(context.Context, string, string, netip.Addr, uint16, bool) error {
+	return nil
+}
+func (m mockFirewall) TempDropOutputTCPRST(context.Context, netip.AddrPort, netip.AddrPort, int) (func(context.Context) error, error) {
+	return func(context.Context) error { return nil }, nil
+}
+
+type mockLogger struct{}
+
+func (m mockLogger) Debug(string)                           {}
+func (m mockLogger) Debugf(string, ...interface{})          {}
+func (m mockLogger) Info(string)                            {}
+func (m mockLogger) Warn(string)                            {}
+func (m mockLogger) Error(string)                           {}
+func (m mockLogger) Errorf(string, ...interface{})          {}
+
+func Test_setupWireguard(t *testing.T) {
+	t.Parallel()
+
+	validPrivKey := "yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk="
+	validPubKey := "1/5n4w0b6K3m1h4/7h0f+z2V7h0b6K3m1h4/7h0f+z0="
+
+	testCases := map[string]struct {
+		providerConf       mockWireguardProvider
+		isWireguardConfig  bool
+		settings           settings.VPN
+		firewall           mockFirewall
+		expectedConnection models.Connection
+		expectedErr        error
+	}{
+		"standard provider success": {
+			providerConf: mockWireguardProvider{
+				mockProvider: mockProvider{
+					connection: models.Connection{
+						IP:     netip.AddrFrom4([4]byte{1, 2, 3, 4}),
+						Port:   51820,
+						PubKey: validPubKey,
+					},
+				},
+			},
+			isWireguardConfig: false,
+			settings: settings.VPN{
+				Wireguard: settings.Wireguard{
+					PrivateKey:                  ptrTo(validPrivKey),
+					PreSharedKey:                ptrTo(""),
+					Addresses:                   []netip.Prefix{netip.PrefixFrom(netip.AddrFrom4([4]byte{10, 0, 0, 2}), 32)},
+					AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+					PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+					Interface:                   "wg0",
+					MTU:                         ptrTo(uint32(0)),
+					Implementation:              "auto",
+					GSO:                         ptrTo(true),
+				},
+			},
+			expectedConnection: models.Connection{
+				IP:     netip.AddrFrom4([4]byte{1, 2, 3, 4}),
+				Port:   51820,
+				PubKey: validPubKey,
+			},
+		},
+		"wireguard configer success": {
+			providerConf: mockWireguardProvider{
+				mockProvider: mockProvider{
+					connection: models.Connection{
+						IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+						Port:       1337,
+						ServerName: "bahamas413",
+					},
+				},
+				wireguardConfig: func(_ context.Context, conn *models.Connection,
+					_ settings.VPN, wgSettings wireguard.Settings, _ common.Firewall,
+				) (wireguard.Settings, error) {
+					wgSettings.PrivateKey = validPrivKey
+					wgSettings.PublicKey = validPubKey
+					wgSettings.Addresses = []netip.Prefix{
+						netip.PrefixFrom(netip.AddrFrom4([4]byte{10, 0, 0, 2}), 32),
+					}
+					conn.PubKey = validPubKey
+					return wgSettings, nil
+				},
+			},
+			isWireguardConfig: true,
+			settings: settings.VPN{
+				Wireguard: settings.Wireguard{
+					PrivateKey:                  ptrTo(""),
+					PreSharedKey:                ptrTo(""),
+					AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+					PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+					Interface:                   "wg0",
+					MTU:                         ptrTo(uint32(0)),
+					Implementation:              "auto",
+					GSO:                         ptrTo(true),
+				},
+			},
+			expectedConnection: models.Connection{
+				IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+				Port:       1337,
+				ServerName: "bahamas413",
+				PubKey:     validPubKey,
+			},
+		},
+		"wireguard configer error": {
+			providerConf: mockWireguardProvider{
+				mockProvider: mockProvider{
+					connection: models.Connection{
+						IP:         netip.AddrFrom4([4]byte{95, 181, 238, 98}),
+						Port:       1337,
+						ServerName: "bahamas413",
+					},
+				},
+				wireguardConfig: func(context.Context, *models.Connection,
+					settings.VPN, wireguard.Settings, common.Firewall,
+				) (wireguard.Settings, error) {
+					return wireguard.Settings{}, errors.New("auth failed")
+				},
+			},
+			isWireguardConfig: true,
+			settings: settings.VPN{
+				Wireguard: settings.Wireguard{
+					PrivateKey:                  ptrTo(""),
+					PreSharedKey:                ptrTo(""),
+					AllowedIPs:                  []netip.Prefix{netip.PrefixFrom(netip.IPv4Unspecified(), 0)},
+					PersistentKeepaliveInterval: ptrTo(time.Duration(0)),
+					Interface:                   "wg0",
+					MTU:                         ptrTo(uint32(0)),
+					Implementation:              "auto",
+					GSO:                         ptrTo(true),
+				},
+			},
+			expectedErr: errors.New("configuring wireguard: auth failed"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var prov provider.Provider = testCase.providerConf.mockProvider
+			if testCase.isWireguardConfig {
+				prov = testCase.providerConf
+			}
+
+			netlinker := (NetLinker)(nil)
+			fw := testCase.firewall
+			const ipv6SupportLevel = netlink.IPv6Unsupported
+			logger := mockLogger{}
+
+			wireguarder, connection, err := setupWireguard(t.Context(), netlinker,
+				fw, prov, testCase.settings, ipv6SupportLevel, logger)
+
+			if testCase.expectedErr != nil {
+				assert.Equal(t, testCase.expectedErr.Error(), err.Error())
+				assert.Nil(t, wireguarder)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, wireguarder)
+			assert.Equal(t, testCase.expectedConnection, connection)
 		})
 	}
 }


### PR DESCRIPTION

<!-- ⚠️ Respect this format or your PR will be closed automatically -->

# Type

Please tick which one the following applies to your pull request:

- [ ] it is AI generated 🤖 and I did review it 👨👩
- [ ] it is humanly written like the good old days 👨‍🎨👩‍🎨
- [x] it is AI generated 🤖 I did not review it 💤

> I review the implementation but not the tests

# Description

- Implement Wireguard configuration logic in the Private Internet Access provider.
- Create functions to handle token fetching and Wireguard key addition.
- Add tests for Wireguard configuration and related functionalities.
- Update interfaces to include WireguardConfiger for better integration.
- Enhance existing VPN setup to support Wireguard configurations.

# Issue (optional)

<!-- Optionally link to the issue(s) this change relates to. -->

# Gluetun wiki associated pull request (optional)

<!-- Optionally link to the pull request for the Gluetun wiki -->
