### PR TITLE
fix(firewall/iptables): filter out jump rules to Docker NAT chains too

### DIFF
--- a/internal/firewall/iptables/atomic.go
+++ b/internal/firewall/iptables/atomic.go
@@ -107,8 +107,13 @@ func filterData(cmdOutput []byte) (filtered string, err error) {
 		case strings.HasPrefix(line, ":DOCKER_OUTPUT"),
 			strings.HasPrefix(line, ":DOCKER_POSTROUTING"),
 			strings.HasPrefix(line, "-A DOCKER_OUTPUT"),
-			strings.HasPrefix(line, "-A DOCKER_POSTROUTING"):
-			// Do not touch (aka save and restore) NAT rules added by Docker
+			strings.HasPrefix(line, "-A DOCKER_POSTROUTING"),
+			strings.HasSuffix(line, "-j DOCKER_OUTPUT"),
+			strings.HasSuffix(line, "-j DOCKER_POSTROUTING"):
+			// Do not touch (aka save and restore) NAT rules added by Docker,
+			// nor the rules jumping to them, otherwise iptables-restore fails
+			// with 'Couldn't load target' since the jump target chain would
+			// be undefined in the filtered ruleset.
 			continue
 		case strings.Contains(line, "[unsupported revision]"):
 			return "", fmt.Errorf("mismatch container iptables-save and kernel: %s", line)

--- a/internal/firewall/iptables/atomic_test.go
+++ b/internal/firewall/iptables/atomic_test.go
@@ -1,0 +1,76 @@
+package iptables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_filterData(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		cmdOutput  string
+		filtered   string
+		errMessage string
+	}{
+		"empty": {},
+		"unsupported_revision": {
+			cmdOutput:  "-A INPUT -j ACCEPT [unsupported revision]",
+			errMessage: "mismatch container iptables-save and kernel: " +
+				"-A INPUT -j ACCEPT [unsupported revision]",
+		},
+		"no_docker_chains": {
+			cmdOutput: "*filter\n" +
+				":INPUT DROP [0:0]\n" +
+				"-A INPUT -i lo -j ACCEPT\n" +
+				"COMMIT",
+			filtered: "*filter\n" +
+				":INPUT DROP [0:0]\n" +
+				"-A INPUT -i lo -j ACCEPT\n" +
+				"COMMIT",
+		},
+		"docker_output_and_postrouting_chains_and_jumps_filtered_out": {
+			cmdOutput: "*nat\n" +
+				":PREROUTING ACCEPT [2:120]\n" +
+				":OUTPUT ACCEPT [0:0]\n" +
+				":POSTROUTING ACCEPT [0:0]\n" +
+				":DEFAULT_OUTPUT - [0:0]\n" +
+				":DEFAULT_POSTROUTING - [0:0]\n" +
+				":DOCKER_OUTPUT - [0:0]\n" +
+				":DOCKER_POSTROUTING - [0:0]\n" +
+				"-A OUTPUT -j DEFAULT_OUTPUT\n" +
+				"-A POSTROUTING -j DEFAULT_POSTROUTING\n" +
+				"-A DEFAULT_OUTPUT -d 127.0.0.11/32 -j DOCKER_OUTPUT\n" +
+				"-A DEFAULT_POSTROUTING -d 127.0.0.11/32 -j DOCKER_POSTROUTING\n" +
+				"-A DOCKER_OUTPUT -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j DNAT --to-destination 127.0.0.11:39001\n" +
+				"-A DOCKER_POSTROUTING -d 127.0.0.11/32 -p tcp -m tcp --dport 53 -j SNAT --to-source :39001\n" +
+				"COMMIT",
+			filtered: "*nat\n" +
+				":PREROUTING ACCEPT [2:120]\n" +
+				":OUTPUT ACCEPT [0:0]\n" +
+				":POSTROUTING ACCEPT [0:0]\n" +
+				":DEFAULT_OUTPUT - [0:0]\n" +
+				":DEFAULT_POSTROUTING - [0:0]\n" +
+				"-A OUTPUT -j DEFAULT_OUTPUT\n" +
+				"-A POSTROUTING -j DEFAULT_POSTROUTING\n" +
+				"COMMIT",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			filtered, err := filterData([]byte(testCase.cmdOutput))
+
+			if testCase.errMessage != "" {
+				assert.EqualError(t, err, testCase.errMessage)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.filtered, filtered)
+		})
+	}
+}


### PR DESCRIPTION
<!-- ⚠️ Respect this format or your PR will be closed automatically -->

# Type

Please tick which one the following applies to your pull request:

- [x] it is AI generated 🤖 and I did review it 👨👩
- [ ] it is humanly written like the good old days 👨‍🎨👩‍🎨
- [ ] it is AI generated 🤖 I did not review it 💤

# Description

`filterData()` in `internal/firewall/iptables/atomic.go` (added by the recent
`d3e089cc` hotfix) strips the `DOCKER_OUTPUT`/`DOCKER_POSTROUTING` chain
declarations and rules from the saved iptables ruleset before Gluetun
restores it, so it doesn't clobber Docker-managed NAT rules on shutdown.

It only filtered the chain declarations and the rules *inside* those chains,
but left behind the jump rules that Gluetun's own `DEFAULT_OUTPUT`/
`DEFAULT_POSTROUTING` chains use to reach them, e.g.:

```
-A DEFAULT_OUTPUT -d 127.0.0.11/32 -j DOCKER_OUTPUT
```

Once the target chain declaration is filtered out, this jump references a
chain that no longer exists in the restored ruleset, so `iptables-restore`
fails:

```
iptables-restore v1.8.11 (legacy): Couldn't load target `DOCKER_OUTPUT': No such file or directory
```

This fix also filters out lines ending in `-j DOCKER_OUTPUT` or
`-j DOCKER_POSTROUTING`, so the dangling jump rules are removed along with
the chains they point to.

Added `Test_filterData` covering the empty-input, unsupported-revision-error,
pass-through, and Docker-chain-filtering cases, using the exact ruleset
shape reported in the linked issue comment.

# Issue (optional)

Logs and repro reported in a comment on #3152: https://github.com/passteque/gluetun/issues/3152#issuecomment-5357472125

Note: #3152 itself tracks a separate conntrack-flush issue on older kernels;
this PR fixes a distinct bug (iptables-restore failing on the DOCKER_OUTPUT/
DOCKER_POSTROUTING jump rules) that was reported as a comment on that thread
while testing pr-3158.

# Gluetun wiki associated pull request (optional)

N/A
