### PR TITLE
fix(natpmp): retry on connection refused errors, like timeouts - Fix #3462

### DIFF
--- a/internal/natpmp/helpers_test.go
+++ b/internal/natpmp/helpers_test.go
@@ -6,31 +6,54 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qdm12/gluetun/internal/pmtud/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // enough for slow machines for local UDP server.
 const initialConnectionDuration = 3 * time.Second
 
-// allocateClosedUDPPort returns the port of a UDP socket which is
-// closed immediately, so that no process is listening on it.
-// The OS sends back an ICMP port unreachable message for datagrams
-// sent to that port, which surfaces on the sender as a connection
-// refused error on read.
-func allocateClosedUDPPort(t *testing.T) (port uint16) {
+// reserveClosedPort returns a UDP port which is reserved by a TCP socket
+// which is bound but not listening, so that no UDP process is listening on
+// it and the OS cannot assign the port to another process. The OS sends
+// back an ICMP port unreachable message for datagrams sent to that port,
+// which surfaces on the sender as a connection refused error on read.
+func reserveClosedPort(t *testing.T) (port uint16) {
 	t.Helper()
 
-	conn, err := net.ListenUDP("udp", nil)
+	fd, err := unix.Socket(constants.AF_INET, constants.SOCK_STREAM, constants.IPPROTO_TCP)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := unix.Close(fd)
+		assert.NoError(t, err)
+	})
 
-	localAddress, ok := conn.LocalAddr().(*net.UDPAddr)
-	require.True(t, ok, "listening address is not UDP")
+	addr := &unix.SockaddrInet4{
+		Port: 0,
+		Addr: [4]byte{127, 0, 0, 1},
+	}
 
-	err = conn.Close()
-	require.NoError(t, err)
+	err = unix.Bind(fd, addr)
+	if err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
 
-	return uint16(localAddress.Port) //nolint:gosec
+	sockAddr, err := unix.Getsockname(fd)
+	if err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
+
+	sockAddr4, ok := sockAddr.(*unix.SockaddrInet4)
+	if !ok {
+		_ = unix.Close(fd)
+		t.Fatal("not an IPv4 address")
+	}
+
+	return uint16(sockAddr4.Port) //nolint:gosec
 }
 
 type udpExchange struct {

--- a/internal/natpmp/helpers_test.go
+++ b/internal/natpmp/helpers_test.go
@@ -6,55 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qdm12/gluetun/internal/pmtud/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 )
 
 // enough for slow machines for local UDP server.
 const initialConnectionDuration = 3 * time.Second
-
-// reserveClosedPort returns a UDP port which is reserved by a TCP socket
-// which is bound but not listening, so that no UDP process is listening on
-// it and the OS cannot assign the port to another process. The OS sends
-// back an ICMP port unreachable message for datagrams sent to that port,
-// which surfaces on the sender as a connection refused error on read.
-func reserveClosedPort(t *testing.T) (port uint16) {
-	t.Helper()
-
-	fd, err := unix.Socket(constants.AF_INET, constants.SOCK_STREAM, constants.IPPROTO_TCP)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		err := unix.Close(fd)
-		assert.NoError(t, err)
-	})
-
-	addr := &unix.SockaddrInet4{
-		Port: 0,
-		Addr: [4]byte{127, 0, 0, 1},
-	}
-
-	err = unix.Bind(fd, addr)
-	if err != nil {
-		_ = unix.Close(fd)
-		t.Fatal(err)
-	}
-
-	sockAddr, err := unix.Getsockname(fd)
-	if err != nil {
-		_ = unix.Close(fd)
-		t.Fatal(err)
-	}
-
-	sockAddr4, ok := sockAddr.(*unix.SockaddrInet4)
-	if !ok {
-		_ = unix.Close(fd)
-		t.Fatal("not an IPv4 address")
-	}
-
-	return uint16(sockAddr4.Port) //nolint:gosec
-}
 
 type udpExchange struct {
 	request  []byte

--- a/internal/natpmp/helpers_test.go
+++ b/internal/natpmp/helpers_test.go
@@ -13,6 +13,26 @@ import (
 // enough for slow machines for local UDP server.
 const initialConnectionDuration = 3 * time.Second
 
+// allocateClosedUDPPort returns the port of a UDP socket which is
+// closed immediately, so that no process is listening on it.
+// The OS sends back an ICMP port unreachable message for datagrams
+// sent to that port, which surfaces on the sender as a connection
+// refused error on read.
+func allocateClosedUDPPort(t *testing.T) (port uint16) {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp", nil)
+	require.NoError(t, err)
+
+	localAddress, ok := conn.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok, "listening address is not UDP")
+
+	err = conn.Close()
+	require.NoError(t, err)
+
+	return uint16(localAddress.Port) //nolint:gosec
+}
+
 type udpExchange struct {
 	request  []byte
 	response []byte

--- a/internal/natpmp/helpers_unix_test.go
+++ b/internal/natpmp/helpers_unix_test.go
@@ -1,0 +1,54 @@
+//go:build linux || darwin
+
+package natpmp
+
+import (
+	"testing"
+
+	"github.com/qdm12/gluetun/internal/pmtud/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// reserveClosedPort returns a port with no UDP listener, so that UDP
+// datagrams sent to it get an ICMP port unreachable message, which surfaces
+// on the sender as a connection refused error on read. The port is kept
+// reserved, so that the OS cannot assign it to another process, by a TCP
+// socket which is bound but not listening: a bound UDP socket would be a UDP
+// listener and would receive the datagrams instead of refusing them.
+func reserveClosedPort(t *testing.T) (port uint16) {
+	t.Helper()
+
+	fd, err := unix.Socket(constants.AF_INET, constants.SOCK_STREAM, constants.IPPROTO_TCP)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := unix.Close(fd)
+		assert.NoError(t, err)
+	})
+
+	addr := &unix.SockaddrInet4{
+		Port: 0,
+		Addr: [4]byte{127, 0, 0, 1},
+	}
+
+	err = unix.Bind(fd, addr)
+	if err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
+
+	sockAddr, err := unix.Getsockname(fd)
+	if err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
+
+	sockAddr4, ok := sockAddr.(*unix.SockaddrInet4)
+	if !ok {
+		_ = unix.Close(fd)
+		t.Fatal("not an IPv4 address")
+	}
+
+	return uint16(sockAddr4.Port) //nolint:gosec
+}

--- a/internal/natpmp/helpers_unspecified_test.go
+++ b/internal/natpmp/helpers_unspecified_test.go
@@ -1,0 +1,11 @@
+//go:build !linux && !darwin
+
+package natpmp
+
+import "testing"
+
+// reserveClosedPort is not implemented on this platform.
+func reserveClosedPort(t *testing.T) (port uint16) {
+	t.Helper()
+	panic("not implemented")
+}

--- a/internal/natpmp/portmapping_test.go
+++ b/internal/natpmp/portmapping_test.go
@@ -45,7 +45,7 @@ func Test_Client_AddPortMapping(t *testing.T) {
 			lifetime:                  1200 * time.Second,
 			initialConnectionDuration: time.Millisecond,
 			exchanges:                 []udpExchange{{close: true}},
-			errMessage: "executing remote procedure call: connection timeout: failed attempts: " +
+			errMessage: "executing remote procedure call: connection failed: failed attempts: " +
 				"read udp 127.0.0.1:[1-9][0-9]{0,4}->127.0.0.1:[1-9][0-9]{0,4}: i/o timeout \\(try 1\\)",
 		},
 		"add_udp": {

--- a/internal/natpmp/rpc.go
+++ b/internal/natpmp/rpc.go
@@ -83,10 +83,9 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 
 		bytesRead, receivedRemoteAddress, err := connection.ReadFromUDP(response)
 		if err != nil {
-			shouldRetry, finalErr := retryAfterReadError(ctx, connectionDuration,
-				c.maxRetries, retryCount, err)
-			if !shouldRetry {
-				return nil, finalErr
+			if retryErr := retryAfterReadError(ctx, connectionDuration,
+				c.maxRetries, retryCount, err); retryErr != nil {
+				return nil, fmt.Errorf("reading from udp connection: %w", retryErr)
 			}
 			connectionDuration *= 2
 			failedAttempts = append(failedAttempts, err.Error())
@@ -123,38 +122,35 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 	return response, nil
 }
 
-// retryAfterReadError reports whether the request should be retried after a
-// read error, waiting for the retry pacing when needed. A read error is
-// retryable when it is a timeout, meaning the gateway did not respond, or a
-// connection refused error, which is the OS translation of an ICMP port
+// retryAfterReadError returns an error when the request must not be retried
+// after a read error, waiting for the retry pacing when needed. A read error
+// is retryable when it is a timeout, meaning the gateway did not respond, or
+// a connection refused error, which is the OS translation of an ICMP port
 // unreachable message, meaning nothing was listening on the gateway port at
 // that instant. A timed out read already waited for the connection duration
 // to elapse, so only a refused read requires an explicit wait, to keep the
 // same retry pace.
 func retryAfterReadError(ctx context.Context, connectionDuration time.Duration,
 	maxRetries, retryCount uint, readErr error,
-) (shouldRetry bool, finalErr error) {
+) (err error) {
 	if ctx.Err() != nil {
-		return false, fmt.Errorf("reading from udp connection: %w", ctx.Err())
+		return ctx.Err()
 	}
 	var netErr net.Error
 	isTimeout := errors.As(readErr, &netErr) && netErr.Timeout()
 	isConnectionRefused := errors.Is(readErr, syscall.ECONNREFUSED)
 	if !isTimeout && !isConnectionRefused {
-		return false, fmt.Errorf("reading from udp connection: %w", readErr)
+		return readErr
 	}
 	if !isTimeout && retryCount+1 < maxRetries {
-		waitTimer := time.NewTimer(connectionDuration)
+		timer := time.NewTimer(connectionDuration)
 		select {
 		case <-ctx.Done():
-			if !waitTimer.Stop() {
-				<-waitTimer.C
-			}
-			return false, ctx.Err()
-		case <-waitTimer.C:
+			return ctx.Err()
+		case <-timer.C:
 		}
 	}
-	return true, nil
+	return nil
 }
 
 func dedupFailedAttempts(failedAttempts []string) (errorMessage string) {

--- a/internal/natpmp/rpc.go
+++ b/internal/natpmp/rpc.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -82,16 +83,14 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 
 		bytesRead, receivedRemoteAddress, err := connection.ReadFromUDP(response)
 		if err != nil {
-			if ctx.Err() != nil {
-				return nil, fmt.Errorf("reading from udp connection: %w", ctx.Err())
+			shouldRetry, finalErr := retryAfterReadError(ctx, connectionDuration,
+				c.maxRetries, retryCount, err)
+			if !shouldRetry {
+				return nil, finalErr
 			}
-			var netErr net.Error
-			if errors.As(err, &netErr) && netErr.Timeout() {
-				connectionDuration *= 2
-				failedAttempts = append(failedAttempts, netErr.Error())
-				continue
-			}
-			return nil, fmt.Errorf("reading from udp connection: %w", err)
+			connectionDuration *= 2
+			failedAttempts = append(failedAttempts, err.Error())
+			continue
 		}
 
 		if !receivedRemoteAddress.IP.Equal(gatewayAddress.IP) {
@@ -109,7 +108,7 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 	}
 
 	if retryCount == c.maxRetries {
-		return nil, fmt.Errorf("connection timeout: failed attempts: %s", dedupFailedAttempts(failedAttempts))
+		return nil, fmt.Errorf("connection failed: failed attempts: %s", dedupFailedAttempts(failedAttempts))
 	}
 
 	// Opcodes between 0 and 127 are client requests.  Opcodes from 128 to
@@ -122,6 +121,40 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 	}
 
 	return response, nil
+}
+
+// retryAfterReadError reports whether the request should be retried after a
+// read error, waiting for the retry pacing when needed. A read error is
+// retryable when it is a timeout, meaning the gateway did not respond, or a
+// connection refused error, which is the OS translation of an ICMP port
+// unreachable message, meaning nothing was listening on the gateway port at
+// that instant. A timed out read already waited for the connection duration
+// to elapse, so only a refused read requires an explicit wait, to keep the
+// same retry pace.
+func retryAfterReadError(ctx context.Context, connectionDuration time.Duration,
+	maxRetries, retryCount uint, readErr error,
+) (shouldRetry bool, finalErr error) {
+	if ctx.Err() != nil {
+		return false, fmt.Errorf("reading from udp connection: %w", ctx.Err())
+	}
+	var netErr net.Error
+	isTimeout := errors.As(readErr, &netErr) && netErr.Timeout()
+	isConnectionRefused := errors.Is(readErr, syscall.ECONNREFUSED)
+	if !isTimeout && !isConnectionRefused {
+		return false, fmt.Errorf("reading from udp connection: %w", readErr)
+	}
+	if !isTimeout && retryCount+1 < maxRetries {
+		waitTimer := time.NewTimer(connectionDuration)
+		select {
+		case <-ctx.Done():
+			if !waitTimer.Stop() {
+				<-waitTimer.C
+			}
+			return false, ctx.Err()
+		case <-waitTimer.C:
+		}
+	}
+	return true, nil
 }
 
 func dedupFailedAttempts(failedAttempts []string) (errorMessage string) {

--- a/internal/natpmp/rpc.go
+++ b/internal/natpmp/rpc.go
@@ -83,9 +83,9 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 
 		bytesRead, receivedRemoteAddress, err := connection.ReadFromUDP(response)
 		if err != nil {
-			if retryErr := retryAfterReadError(ctx, connectionDuration,
-				c.maxRetries, retryCount, err); retryErr != nil {
-				return nil, fmt.Errorf("reading from udp connection: %w", retryErr)
+			if fatalErr := handleReadError(ctx, connectionDuration,
+				c.maxRetries, retryCount, err); fatalErr != nil {
+				return nil, fmt.Errorf("reading from udp connection: %w", fatalErr)
 			}
 			connectionDuration *= 2
 			failedAttempts = append(failedAttempts, err.Error())
@@ -122,15 +122,15 @@ func (c *Client) rpc(ctx context.Context, gateway netip.Addr,
 	return response, nil
 }
 
-// retryAfterReadError returns an error when the request must not be retried
-// after a read error, waiting for the retry pacing when needed. A read error
-// is retryable when it is a timeout, meaning the gateway did not respond, or
-// a connection refused error, which is the OS translation of an ICMP port
+// handleReadError returns the error to return when the read error is not
+// retryable, waiting for the retry pacing when needed. A read error is
+// retryable when it is a timeout, meaning the gateway did not respond, or a
+// connection refused error, which is the OS translation of an ICMP port
 // unreachable message, meaning nothing was listening on the gateway port at
 // that instant. A timed out read already waited for the connection duration
 // to elapse, so only a refused read requires an explicit wait, to keep the
 // same retry pace.
-func retryAfterReadError(ctx context.Context, connectionDuration time.Duration,
+func handleReadError(ctx context.Context, connectionDuration time.Duration,
 	maxRetries, retryCount uint, readErr error,
 ) (err error) {
 	if ctx.Err() != nil {

--- a/internal/natpmp/rpc_test.go
+++ b/internal/natpmp/rpc_test.go
@@ -18,7 +18,9 @@ func Test_Client_rpc(t *testing.T) {
 		request                   []byte
 		responseSize              uint
 		initialConnectionDuration time.Duration
+		maxRetries                uint
 		exchanges                 []udpExchange
+		closedPort                bool
 		expectedResponse          []byte
 		errMessage                string
 	}{
@@ -50,8 +52,19 @@ func Test_Client_rpc(t *testing.T) {
 			exchanges: []udpExchange{
 				{request: []byte{0, 1}, close: true},
 			},
-			errMessage: "connection timeout: failed attempts: " +
+			errMessage: "connection failed: failed attempts: " +
 				"read udp 127.0.0.1:[1-9][0-9]{0,4}->127.0.0.1:[1-9][0-9]{0,4}: i/o timeout \\(try 1\\)",
+		},
+		"read_connection_refused_retried": {
+			ctx:                       context.Background(),
+			gateway:                   netip.AddrFrom4([4]byte{127, 0, 0, 1}),
+			request:                   []byte{0, 1},
+			initialConnectionDuration: 50 * time.Millisecond,
+			maxRetries:                3,
+			closedPort:                true,
+			errMessage: "connection failed: failed attempts: " +
+				"read udp 127.0.0.1:[1-9][0-9]{0,4}->127.0.0.1:[1-9][0-9]{0,4}: " +
+				"recvfrom: connection refused \\(tries 1, 2, 3\\)",
 		},
 		"response_too_small": {
 			ctx:                       context.Background(),
@@ -132,12 +145,24 @@ func Test_Client_rpc(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			remoteAddress := launchUDPServer(t, testCase.exchanges)
+			var serverPort uint16
+			switch {
+			case testCase.closedPort:
+				serverPort = allocateClosedUDPPort(t)
+			default:
+				remoteAddress := launchUDPServer(t, testCase.exchanges)
+				serverPort = uint16(remoteAddress.Port) //nolint:gosec
+			}
+
+			maxRetries := testCase.maxRetries
+			if maxRetries == 0 {
+				maxRetries = 1
+			}
 
 			client := Client{
-				serverPort:                uint16(remoteAddress.Port), //nolint:gosec
+				serverPort:                serverPort,
 				initialConnectionDuration: testCase.initialConnectionDuration,
-				maxRetries:                1,
+				maxRetries:                maxRetries,
 			}
 
 			response, err := client.rpc(testCase.ctx, testCase.gateway,

--- a/internal/natpmp/rpc_test.go
+++ b/internal/natpmp/rpc_test.go
@@ -27,19 +27,22 @@ func Test_Client_rpc(t *testing.T) {
 		"gateway_ip_unspecified": {
 			gateway:    netip.IPv6Unspecified(),
 			request:    []byte{0, 0},
+			maxRetries: 1,
 			errMessage: "gateway IP is unspecified",
 		},
 		"request_too_small": {
 			gateway:                   netip.AddrFrom4([4]byte{127, 0, 0, 1}),
 			request:                   []byte{0},
 			initialConnectionDuration: time.Nanosecond, // doesn't matter
+			maxRetries:                1,
 			errMessage: `checking request: message size is too small: ` +
 				`need at least 2 bytes and got 1 byte\(s\)`,
 		},
 		"write_error": {
-			ctx:     context.Background(),
-			gateway: netip.AddrFrom4([4]byte{127, 0, 0, 1}),
-			request: []byte{0, 0},
+			ctx:        context.Background(),
+			gateway:    netip.AddrFrom4([4]byte{127, 0, 0, 1}),
+			request:    []byte{0, 0},
+			maxRetries: 1,
 			errMessage: `writing to connection: write udp ` +
 				`127.0.0.1:[1-9][0-9]{0,4}->127.0.0.1:[1-9][0-9]{0,4}: ` +
 				`i/o timeout`,
@@ -48,7 +51,8 @@ func Test_Client_rpc(t *testing.T) {
 			ctx:                       context.Background(),
 			gateway:                   netip.AddrFrom4([4]byte{127, 0, 0, 1}),
 			request:                   []byte{0, 1},
-			initialConnectionDuration: time.Millisecond,
+			initialConnectionDuration: 100 * time.Millisecond, // enough margin for the server to read the request under load
+			maxRetries:                1,
 			exchanges: []udpExchange{
 				{request: []byte{0, 1}, close: true},
 			},
@@ -71,6 +75,7 @@ func Test_Client_rpc(t *testing.T) {
 			gateway:                   netip.AddrFrom4([4]byte{127, 0, 0, 1}),
 			request:                   []byte{0, 0},
 			initialConnectionDuration: initialConnectionDuration,
+			maxRetries:                1,
 			exchanges: []udpExchange{{
 				request:  []byte{0, 0},
 				response: []byte{1},
@@ -84,6 +89,7 @@ func Test_Client_rpc(t *testing.T) {
 			request:                   []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 			responseSize:              5,
 			initialConnectionDuration: initialConnectionDuration,
+			maxRetries:                1,
 			exchanges: []udpExchange{{
 				request:  []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 				response: []byte{0, 1, 2, 3}, // size 4
@@ -97,6 +103,7 @@ func Test_Client_rpc(t *testing.T) {
 			request:                   []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 			responseSize:              16,
 			initialConnectionDuration: initialConnectionDuration,
+			maxRetries:                1,
 			exchanges: []udpExchange{{
 				request:  []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 				response: []byte{0x1, 0x82, 0x0, 0x0, 0x0, 0x14, 0x4, 0x96, 0x0, 0x7b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -109,6 +116,7 @@ func Test_Client_rpc(t *testing.T) {
 			request:                   []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 			responseSize:              16,
 			initialConnectionDuration: initialConnectionDuration,
+			maxRetries:                1,
 			exchanges: []udpExchange{{
 				request:  []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 				response: []byte{0x0, 0x88, 0x0, 0x0, 0x0, 0x14, 0x4, 0x96, 0x0, 0x7b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -121,6 +129,7 @@ func Test_Client_rpc(t *testing.T) {
 			request:                   []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 			responseSize:              16,
 			initialConnectionDuration: initialConnectionDuration,
+			maxRetries:                1,
 			exchanges: []udpExchange{{
 				request:  []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 				response: []byte{0x0, 0x82, 0x0, 0x11, 0x0, 0x14, 0x4, 0x96, 0x0, 0x7b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -133,6 +142,7 @@ func Test_Client_rpc(t *testing.T) {
 			request:                   []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 			responseSize:              16,
 			initialConnectionDuration: initialConnectionDuration,
+			maxRetries:                1,
 			exchanges: []udpExchange{{
 				request:  []byte{0x0, 0x2, 0x0, 0x0, 0x0, 0x7b, 0x1, 0xc8, 0x0, 0x0, 0x4, 0xb0},
 				response: []byte{0x0, 0x82, 0x0, 0x0, 0x0, 0x0, 0x4, 0x96, 0x0, 0x7b, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -148,21 +158,16 @@ func Test_Client_rpc(t *testing.T) {
 			var serverPort uint16
 			switch {
 			case testCase.closedPort:
-				serverPort = allocateClosedUDPPort(t)
+				serverPort = reserveClosedPort(t)
 			default:
 				remoteAddress := launchUDPServer(t, testCase.exchanges)
 				serverPort = uint16(remoteAddress.Port) //nolint:gosec
 			}
 
-			maxRetries := testCase.maxRetries
-			if maxRetries == 0 {
-				maxRetries = 1
-			}
-
 			client := Client{
 				serverPort:                serverPort,
 				initialConnectionDuration: testCase.initialConnectionDuration,
-				maxRetries:                maxRetries,
+				maxRetries:                testCase.maxRetries,
 			}
 
 			response, err := client.rpc(testCase.ctx, testCase.gateway,

--- a/internal/provider/protonvpn/portforward.go
+++ b/internal/provider/protonvpn/portforward.go
@@ -27,7 +27,7 @@ func (p *Provider) PortForward(ctx context.Context, objects utils.PortForwardObj
 	_, externalIPv4Address, err := client.ExternalAddress(ctx, objects.Gateway)
 	if err != nil {
 		switch {
-		case strings.HasSuffix(err.Error(), "connection refused"):
+		case strings.Contains(err.Error(), "connection refused"):
 			err = fmt.Errorf("%w - make sure you have +pmp at the end of your OpenVPN username "+
 				"or that your Wireguard key is set to work with PMP", err)
 		case strings.Contains(err.Error(), "i/o timeout"):


### PR DESCRIPTION
# Type

- [x] it is AI generated 🤖 and I did review it 👨👩
- [ ] it is humanly written like the good old days 👨‍🎨👩‍🎨
- [ ] it is AI generated 🤖 I did not review it 💤

# Description

`KeepPortForward` refreshes the NAT-PMP mapping every 45 s for a 60 s lease. When the gateway refused a single datagram (`recvfrom: connection refused`, the Linux surface of an ICMP port unreachable), the RPC failed immediately because only timeouts were retried. That error then escalated to a full port forwarding teardown and rebuild — port file cleared, firewall rule dropped, up command re-run — even though nothing had been lost and the gateway hands back the very same port.

This implements the fix suggested in the issue: connection refused errors are now retried in `internal/natpmp/rpc.go` like timeouts, covering both the initial acquisition and the refresh, for every NAT-PMP provider. Since a refused read fails instantly (no deadline wait), it waits for the current connection duration before retrying, in a context aware way, keeping exactly the same doubled retry pace as the timeout case and the ~64 s retry window of RFC 6886 §3.1.

A transient hiccup is now invisible to the layers above: the refresh succeeds on a retry well within the 15 s of remaining lease, so there is no `cleanup()`, no port file clearing, and no spurious up command. If the gateway PMP service is genuinely down, the RPC fails after the full retry window like before, and the service restarts.

Two related adjustments:

- the final error is renamed `connection timeout:` to `connection failed:`, since it can now also report connection refused and source IP mismatch attempts;
- the ProtonVPN `+pmp` hint matched with `strings.HasSuffix(err, "connection refused")`, which no longer matches now that the final error ends with the deduplicated attempts list, so it now uses `strings.Contains`.

Tests: new `read_connection_refused_retried` case in `Test_Client_rpc` using a closed UDP port (the OS answers with ICMP port unreachable, i.e. connection refused on read), proving refused attempts are retried and reported; plus a `allocateClosedUDPPort` test helper and a per-test `maxRetries` field.

# Issue (optional)

Fix #3462

# Gluetun wiki associated pull request (optional)
